### PR TITLE
Change WheelbehaviorMode.PanVertical and PanHorizontal to both accept Delta.X and Delta.Y

### DIFF
--- a/src/PanAndZoom/ZoomBorder.cs
+++ b/src/PanAndZoom/ZoomBorder.cs
@@ -464,7 +464,7 @@ public partial class ZoomBorder : Border
             case WheelBehaviorMode.PanVertical:
                 if (EnablePan)
                 {
-                    PanDelta(0, 10 * e.Delta.Y * WheelPanSensitivity);
+                    PanDelta(10 * e.Delta.X * WheelPanSensitivity, 10 * e.Delta.Y * WheelPanSensitivity);
                     e.Handled = true;
                 }
                 break;
@@ -472,7 +472,7 @@ public partial class ZoomBorder : Border
             case WheelBehaviorMode.PanHorizontal:
                 if (EnablePan)
                 {
-                    PanDelta(10 * e.Delta.X * WheelPanSensitivity, 0);
+                    PanDelta(10 * e.Delta.Y * WheelPanSensitivity, 10 * e.Delta.X * WheelPanSensitivity);
                     e.Handled = true;
                 }
                 break;

--- a/tests/Avalonia.Controls.PanAndZoom.UnitTests/ZoomBorderWheelBehaviorTests.cs
+++ b/tests/Avalonia.Controls.PanAndZoom.UnitTests/ZoomBorderWheelBehaviorTests.cs
@@ -364,7 +364,7 @@ public class ZoomBorderWheelBehaviorTests
             0,
             new PointerPointProperties(RawInputModifiers.Shift, PointerUpdateKind.Other),
             KeyModifiers.Shift,
-            new Vector(1, 0)
+            new Vector(0, 1)
         )
         {
             RoutedEvent = InputElement.PointerWheelChangedEvent


### PR DESCRIPTION
Changed WheelBehaviorMode.PanVertical and PanHorizontal to both accept Delta.X and Delta.Y, just switching those when shift is pressed. Updated the WheelBehavior_WithShiftModifier_UsesShiftBehaviorInsteadOfDefault() test to use a vector with y-value for the wheel event, as we still expect regular scrolling of the mouse together with shift to get horizontal scrolling. 

This pull request allows for panning with a touchpad and mouse, and the shift for horizontal scroll to work for a mouse. 

Fixes #129 