### PR TITLE
Updated Codebase to consider LayoutOffset due to centering of the child component in the zoomborder

### DIFF
--- a/samples/AvaloniaDemo.Base/MainView.axaml
+++ b/samples/AvaloniaDemo.Base/MainView.axaml
@@ -201,7 +201,7 @@
                             EnableGestures="True"
                             Background="SlateBlue" ClipToBounds="True" Focusable="True"
                             VerticalAlignment="Stretch" HorizontalAlignment="Stretch">
-              <Border Background="Gray" BorderBrush="Yellow" BorderThickness="10">
+              <Border Background="Gray" BorderBrush="Yellow" BorderThickness="10" Width="400" Height="400">
                 <Border.Transitions>
                   <Transitions>
                     <TransformOperationsTransition Property="RenderTransform" Duration="0:0:0.1" />

--- a/src/PanAndZoom/ZoomBorder.ILogicalScrollable.cs
+++ b/src/PanAndZoom/ZoomBorder.ILogicalScrollable.cs
@@ -244,7 +244,7 @@ public partial class ZoomBorder : ILogicalScrollable
 
         // Account for the layout offset of _element within ZoomBorder
         // and transform the target bounds to viewport coordinates
-        var adjustedBounds = TransformContentToViewport(targetBounds, _element.Bounds.Position, _matrix);
+        var adjustedBounds = TransformContentToViewport(targetBounds, LayoutOffset, _matrix);
 
         // Get current viewport
         var viewportRect = new Rect(0, 0, Bounds.Width, Bounds.Height);

--- a/src/PanAndZoom/ZoomBorder.ILogicalScrollable.cs
+++ b/src/PanAndZoom/ZoomBorder.ILogicalScrollable.cs
@@ -224,7 +224,13 @@ public partial class ZoomBorder : ILogicalScrollable
         // If targetRect has zero size, use the target's bounds
         if (targetRect.Width <= 0 && targetRect.Height <= 0)
         {
-            targetBounds = target.Bounds;
+            // For _element itself, use content-space bounds (origin 0,0) since
+            // target.Bounds.Position is the layout offset, and TransformContentToViewport
+            // will add it again. For other controls, keep target.Bounds as-is since
+            // TransformToVisual below handles the coordinate conversion.
+            targetBounds = target == _element
+                ? new Rect(0, 0, target.Bounds.Width, target.Bounds.Height)
+                : target.Bounds;
         }
 
         // Try to translate target coordinates to our content coordinate system

--- a/src/PanAndZoom/ZoomBorder.ILogicalScrollable.cs
+++ b/src/PanAndZoom/ZoomBorder.ILogicalScrollable.cs
@@ -30,13 +30,20 @@ public partial class ZoomBorder : ILogicalScrollable
     /// <param name="offset">The current scroll offset.</param>
     public static void CalculateScrollable(Rect source, Size borderSize, Matrix matrix, out Size extent, out Size viewport, out Vector offset)
     {
-        var bounds = new Rect(0, 0, source.Width, source.Height);
-            
+        // The source.Position is the LAYOUT position where Avalonia placed the child element
+        // (e.g., centered at (50,50) when child is smaller than ZoomBorder).
+        // This layout offset should NOT be scaled by the zoom matrix - it's a fixed offset
+        // in viewport coordinates, not content coordinates.
+        //
+        // The content itself is in a coordinate system from (0,0) to (Width,Height).
+        // Only the content bounds get transformed by the matrix.
+        
         viewport = borderSize;
 
-        var transformed = bounds.TransformToAABB(matrix);
-
-        Log($"[CalculateScrollable] source: {source}, bounds: {bounds}, transformed: {transformed}");
+        // Use helper to transform content bounds to viewport coordinates (accounts for layout offset)
+        var transformed = TransformContentToViewport(source, matrix);
+        
+        Log($"[CalculateScrollable] source: {source}, transformed: {transformed}");
 
         var width = transformed.Size.Width;
         var height = transformed.Size.Height;
@@ -96,6 +103,43 @@ public partial class ZoomBorder : ILogicalScrollable
         offset = new Vector(offsetX, offsetY);
 
         Log($"[CalculateScrollable] Extent: {extent} | Offset: {offset} | Viewport: {viewport}");
+    }
+
+    /// <summary>
+    /// Transforms content bounds to viewport coordinates, accounting for layout offset.
+    /// </summary>
+    /// <param name="elementBounds">The element bounds (includes Position where Avalonia laid out the element).</param>
+    /// <param name="matrix">The transform matrix.</param>
+    /// <returns>The actual visual bounds in viewport coordinates.</returns>
+    /// <remarks>
+    /// When a child element has a differnt size than the ZoomBorder, Avalonia's layout system
+    /// positions it (e.g., centered) resulting in a non-zero Position in elementBounds.
+    /// This layout offset is in viewport coordinates and should NOT be scaled by the
+    /// transform matrix. This method correctly separates the two coordinate systems.
+    /// </remarks>
+    public static Rect TransformContentToViewport(Rect elementBounds, Matrix matrix)
+    {
+        var layoutOffset = elementBounds.Position;
+        var contentBounds = new Rect(0, 0, elementBounds.Width, elementBounds.Height);
+        return TransformContentToViewport(contentBounds, layoutOffset, matrix);
+    }
+
+    /// <summary>
+    /// Transforms a rectangle in content coordinates to viewport coordinates, accounting for layout offset.
+    /// </summary>
+    /// <param name="contentRect">A rectangle in content coordinates (where 0,0 is the top-left of the content).</param>
+    /// <param name="layoutOffset">The layout offset where Avalonia positioned the element within its parent.</param>
+    /// <param name="matrix">The transform matrix.</param>
+    /// <returns>The rectangle in viewport coordinates.</returns>
+    public static Rect TransformContentToViewport(Rect contentRect, Point layoutOffset, Matrix matrix)
+    {
+        var transformedContent = contentRect.TransformToAABB(matrix);
+        
+        return new Rect(
+            transformedContent.X + layoutOffset.X,
+            transformedContent.Y + layoutOffset.Y,
+            transformedContent.Width,
+            transformedContent.Height);
     }
 
     /// <inheritdoc/>
@@ -198,14 +242,15 @@ public partial class ZoomBorder : ILogicalScrollable
             }
         }
 
-        // Transform the target bounds using current matrix to get viewport coordinates
-        var transformedBounds = targetBounds.TransformToAABB(_matrix);
+        // Account for the layout offset of _element within ZoomBorder
+        // and transform the target bounds to viewport coordinates
+        var adjustedBounds = TransformContentToViewport(targetBounds, _element.Bounds.Position, _matrix);
 
         // Get current viewport
         var viewportRect = new Rect(0, 0, Bounds.Width, Bounds.Height);
 
         // Check if already fully visible
-        if (viewportRect.Contains(transformedBounds))
+        if (viewportRect.Contains(adjustedBounds))
         {
             return true;
         }
@@ -215,23 +260,23 @@ public partial class ZoomBorder : ILogicalScrollable
         var deltaY = 0.0;
 
         // Check horizontal visibility
-        if (transformedBounds.Left < viewportRect.Left)
+        if (adjustedBounds.Left < viewportRect.Left)
         {
-            deltaX = viewportRect.Left - transformedBounds.Left;
+            deltaX = viewportRect.Left - adjustedBounds.Left;
         }
-        else if (transformedBounds.Right > viewportRect.Right)
+        else if (adjustedBounds.Right > viewportRect.Right)
         {
-            deltaX = viewportRect.Right - transformedBounds.Right;
+            deltaX = viewportRect.Right - adjustedBounds.Right;
         }
 
         // Check vertical visibility
-        if (transformedBounds.Top < viewportRect.Top)
+        if (adjustedBounds.Top < viewportRect.Top)
         {
-            deltaY = viewportRect.Top - transformedBounds.Top;
+            deltaY = viewportRect.Top - adjustedBounds.Top;
         }
-        else if (transformedBounds.Bottom > viewportRect.Bottom)
+        else if (adjustedBounds.Bottom > viewportRect.Bottom)
         {
-            deltaY = viewportRect.Bottom - transformedBounds.Bottom;
+            deltaY = viewportRect.Bottom - adjustedBounds.Bottom;
         }
 
         // Apply pan if needed

--- a/src/PanAndZoom/ZoomBorder.ILogicalScrollable.cs
+++ b/src/PanAndZoom/ZoomBorder.ILogicalScrollable.cs
@@ -30,9 +30,9 @@ public partial class ZoomBorder : ILogicalScrollable
     /// <param name="offset">The current scroll offset.</param>
     public static void CalculateScrollable(Rect source, Size borderSize, Matrix matrix, out Size extent, out Size viewport, out Vector offset)
     {
-        // The source.Position is the LAYOUT position where Avalonia placed the child element
-        // (e.g., centered at (50,50) when child is smaller than ZoomBorder).
-        // This layout offset should NOT be scaled by the zoom matrix - it's a fixed offset
+        // The source.Position is the layout position where Avalonia placed the child element
+        // (e.g., centered at (50,50)).
+        // This layout offset should not be scaled by the zoom matrix - it's a fixed offset
         // in viewport coordinates, not content coordinates.
         //
         // The content itself is in a coordinate system from (0,0) to (Width,Height).
@@ -114,7 +114,7 @@ public partial class ZoomBorder : ILogicalScrollable
     /// <remarks>
     /// When a child element has a differnt size than the ZoomBorder, Avalonia's layout system
     /// positions it (e.g., centered) resulting in a non-zero Position in elementBounds.
-    /// This layout offset is in viewport coordinates and should NOT be scaled by the
+    /// This layout offset is in viewport coordinates and should not be scaled by the
     /// transform matrix. This method correctly separates the two coordinate systems.
     /// </remarks>
     public static Rect TransformContentToViewport(Rect elementBounds, Matrix matrix)

--- a/src/PanAndZoom/ZoomBorder.cs
+++ b/src/PanAndZoom/ZoomBorder.cs
@@ -86,7 +86,7 @@ public partial class ZoomBorder : Border
 
     /// <summary>
     /// Gets the layout offset where Avalonia positioned the child element within this ZoomBorder.
-    /// When a child element is smaller than the ZoomBorder, Avalonia centers it, resulting in a
+    /// When a child element is smaller or larger than the ZoomBorder, Avalonia centers it by default, resulting in a
     /// non-zero Bounds.Position. This offset is in viewport coordinates and should NOT be scaled
     /// by the transform matrix when converting between coordinate systems.
     /// </summary>

--- a/src/PanAndZoom/ZoomBorder.cs
+++ b/src/PanAndZoom/ZoomBorder.cs
@@ -997,11 +997,16 @@ public partial class ZoomBorder : Border
         if (_element == null)
             return;
 
+        // Get the layout offset where Avalonia positioned the element
+        var layoutOffset = _element.Bounds.Position;
+
         var viewportCenterX = (Bounds.Width - CenterPadding.Left - CenterPadding.Right) / 2.0 + CenterPadding.Left;
         var viewportCenterY = (Bounds.Height - CenterPadding.Top - CenterPadding.Bottom) / 2.0 + CenterPadding.Top;
 
-        var offsetX = viewportCenterX - point.X * _zoomX;
-        var offsetY = viewportCenterY - point.Y * _zoomY;
+        // The actual visual position is: layoutOffset + matrix offset + point * zoom
+        // So: matrix offset = viewportCenter - layoutOffset - point * zoom
+        var offsetX = viewportCenterX - layoutOffset.X - point.X * _zoomX;
+        var offsetY = viewportCenterY - layoutOffset.Y - point.Y * _zoomY;
 
         Pan(offsetX, offsetY, !animate);
     }
@@ -1017,12 +1022,16 @@ public partial class ZoomBorder : Border
         if (_element == null)
             return;
 
+        // Get the layout offset where Avalonia positioned the element
+        var layoutOffset = _element.Bounds.Position;
+
         var viewportCenterX = (Bounds.Width - CenterPadding.Left - CenterPadding.Right) / 2.0 + CenterPadding.Left;
         var viewportCenterY = (Bounds.Height - CenterPadding.Top - CenterPadding.Bottom) / 2.0 + CenterPadding.Top;
 
-        var matrix = MatrixHelper.ScaleAt(zoom, zoom, point.X, point.Y);
-        var offsetX = viewportCenterX - point.X * zoom;
-        var offsetY = viewportCenterY - point.Y * zoom;
+        // The actual visual position is: layoutOffset + matrix offset + point * zoom
+        // So: matrix offset = viewportCenter - layoutOffset - point * zoom
+        var offsetX = viewportCenterX - layoutOffset.X - point.X * zoom;
+        var offsetY = viewportCenterY - layoutOffset.Y - point.Y * zoom;
 
         _matrix = MatrixHelper.ScaleAndTranslate(zoom, zoom, offsetX, offsetY);
         Invalidate(!animate);
@@ -1075,7 +1084,12 @@ public partial class ZoomBorder : Border
         if (!_matrix.TryInvert(out var inverted))
             return viewportPoint;
 
-        return inverted.Transform(viewportPoint);
+        // Account for layout offset: viewport coordinates need to be adjusted
+        // before applying the inverse matrix transform
+        var layoutOffset = _element?.Bounds.Position ?? new Point(0, 0);
+        var adjustedPoint = new Point(viewportPoint.X - layoutOffset.X, viewportPoint.Y - layoutOffset.Y);
+
+        return inverted.Transform(adjustedPoint);
     }
 
     /// <summary>
@@ -1085,7 +1099,11 @@ public partial class ZoomBorder : Border
     /// <returns>The point in viewport coordinates.</returns>
     public Point ContentToViewport(Point contentPoint)
     {
-        return _matrix.Transform(contentPoint);
+        var transformed = _matrix.Transform(contentPoint);
+
+        // Account for layout offset: add it after the matrix transform
+        var layoutOffset = _element?.Bounds.Position ?? new Point(0, 0);
+        return new Point(transformed.X + layoutOffset.X, transformed.Y + layoutOffset.Y);
     }
 
     /// <summary>
@@ -1098,8 +1116,17 @@ public partial class ZoomBorder : Border
         if (!_matrix.TryInvert(out var inverted))
             return viewportRect;
 
-        var topLeft = inverted.Transform(viewportRect.TopLeft);
-        var bottomRight = inverted.Transform(viewportRect.BottomRight);
+        // Account for layout offset: viewport coordinates need to be adjusted
+        // before applying the inverse matrix transform
+        var layoutOffset = _element?.Bounds.Position ?? new Point(0, 0);
+        var adjustedRect = new Rect(
+            viewportRect.X - layoutOffset.X,
+            viewportRect.Y - layoutOffset.Y,
+            viewportRect.Width,
+            viewportRect.Height);
+
+        var topLeft = inverted.Transform(adjustedRect.TopLeft);
+        var bottomRight = inverted.Transform(adjustedRect.BottomRight);
 
         return new Rect(topLeft, bottomRight);
     }
@@ -1114,7 +1141,13 @@ public partial class ZoomBorder : Border
         var topLeft = _matrix.Transform(contentRect.TopLeft);
         var bottomRight = _matrix.Transform(contentRect.BottomRight);
 
-        return new Rect(topLeft, bottomRight);
+        // Account for layout offset: add it after the matrix transform
+        var layoutOffset = _element?.Bounds.Position ?? new Point(0, 0);
+        return new Rect(
+            topLeft.X + layoutOffset.X,
+            topLeft.Y + layoutOffset.Y,
+            bottomRight.X - topLeft.X,
+            bottomRight.Y - topLeft.Y);
     }
 
     /// <summary>
@@ -1218,6 +1251,9 @@ public partial class ZoomBorder : Border
             return;
         _updating = true;
 
+        // Get the layout offset where Avalonia positioned the element
+        var layoutOffset = _element.Bounds.Position;
+
         var pad = padding ?? new Thickness(0);
         var viewportWidth = Bounds.Width - pad.Left - pad.Right;
         var viewportHeight = Bounds.Height - pad.Top - pad.Bottom;
@@ -1246,13 +1282,10 @@ public partial class ZoomBorder : Border
         var viewportCenterX = pad.Left + viewportWidth / 2.0;
         var viewportCenterY = pad.Top + viewportHeight / 2.0;
 
-        // For a point (x,y) transformed by matrix (zoom, 0, 0, zoom, offsetX, offsetY):
-        // transformed_x = zoom * x + offsetX
-        // We want rectCenter to appear at viewportCenter:
-        // viewportCenterX = zoom * rectCenterX + offsetX
-        // Therefore: offsetX = viewportCenterX - zoom * rectCenterX
-        var offsetX = viewportCenterX - zoom * rectCenterX;
-        var offsetY = viewportCenterY - zoom * rectCenterY;
+        // The actual visual position is: layoutOffset + matrix offset + point * zoom
+        // So: matrix offset = viewportCenter - layoutOffset - point * zoom
+        var offsetX = viewportCenterX - layoutOffset.X - zoom * rectCenterX;
+        var offsetY = viewportCenterY - layoutOffset.Y - zoom * rectCenterY;
 
         _matrix = new Matrix(zoom, 0, 0, zoom, offsetX, offsetY);
         Invalidate(!animate);
@@ -1276,6 +1309,9 @@ public partial class ZoomBorder : Border
             return;
         _updating = true;
 
+        // Get the layout offset where Avalonia positioned the element
+        var layoutOffset = _element.Bounds.Position;
+
         var zoomX = viewportRect.Width / rect.Width;
         var zoomY = viewportRect.Height / rect.Height;
         var zoom = Math.Min(zoomX, zoomY);
@@ -1293,13 +1329,10 @@ public partial class ZoomBorder : Border
         var viewportCenterX = viewportRect.X + viewportRect.Width / 2.0;
         var viewportCenterY = viewportRect.Y + viewportRect.Height / 2.0;
 
-        // For a point (x,y) transformed by matrix (zoom, 0, 0, zoom, offsetX, offsetY):
-        // transformed_x = zoom * x + offsetX
-        // We want rectCenter to appear at viewportCenter:
-        // viewportCenterX = zoom * rectCenterX + offsetX
-        // Therefore: offsetX = viewportCenterX - zoom * rectCenterX
-        var offsetX = viewportCenterX - zoom * rectCenterX;
-        var offsetY = viewportCenterY - zoom * rectCenterY;
+        // The actual visual position is: layoutOffset + matrix offset + point * zoom
+        // So: matrix offset = viewportCenter - layoutOffset - point * zoom
+        var offsetX = viewportCenterX - layoutOffset.X - zoom * rectCenterX;
+        var offsetY = viewportCenterY - layoutOffset.Y - zoom * rectCenterY;
 
         // Temporarily disable constraints
         var previousEnableConstrains = EnableConstrains;
@@ -1872,6 +1905,9 @@ public partial class ZoomBorder : Border
         if (_element == null)
             return;
 
+        // Get the layout offset where Avalonia positioned the element
+        var layoutOffset = _element.Bounds.Position;
+
         var contentWidth = _element.Bounds.Width * _matrix.M11;
         var contentHeight = _element.Bounds.Height * _matrix.M22;
         var viewportWidth = Bounds.Width;
@@ -1886,14 +1922,21 @@ public partial class ZoomBorder : Border
         // Apply padding
         var padding = BoundsPadding;
 
+        // The actual visual position is: layoutOffset + matrix offset
+        // So: matrix offset = desired visual position - layoutOffset
+        
         // Constrain X
-        var maxOffsetX = viewportWidth - minVisibleWidth + padding.Right;
-        var minOffsetX = -contentWidth + minVisibleWidth - padding.Left;
+        // Visual position range: [minVisibleWidth - contentWidth - padding.Left, viewportWidth - minVisibleWidth + padding.Right]
+        // Matrix offset range: visual range shifted by -layoutOffset.X
+        var maxOffsetX = viewportWidth - minVisibleWidth + padding.Right - layoutOffset.X;
+        var minOffsetX = -contentWidth + minVisibleWidth - padding.Left - layoutOffset.X;
         offsetX = ClampValue(offsetX, minOffsetX, maxOffsetX);
 
         // Constrain Y
-        var maxOffsetY = viewportHeight - minVisibleHeight + padding.Bottom;
-        var minOffsetY = -contentHeight + minVisibleHeight - padding.Top;
+        // Visual position range: [minVisibleHeight - contentHeight - padding.Top, viewportHeight - minVisibleHeight + padding.Bottom]
+        // Matrix offset range: visual range shifted by -layoutOffset.Y
+        var maxOffsetY = viewportHeight - minVisibleHeight + padding.Bottom - layoutOffset.Y;
+        var minOffsetY = -contentHeight + minVisibleHeight - padding.Top - layoutOffset.Y;
         offsetY = ClampValue(offsetY, minOffsetY, maxOffsetY);
 
         _matrix = new Matrix(_matrix.M11, 0.0, 0.0, _matrix.M22, offsetX, offsetY);
@@ -1904,6 +1947,9 @@ public partial class ZoomBorder : Border
         if (_element == null)
             return;
 
+        // Get the layout offset where Avalonia positioned the element
+        var layoutOffset = _element.Bounds.Position;
+
         var contentWidth = _element.Bounds.Width * _matrix.M11;
         var contentHeight = _element.Bounds.Height * _matrix.M22;
         var viewportWidth = Bounds.Width;
@@ -1912,25 +1958,37 @@ public partial class ZoomBorder : Border
         var offsetX = _matrix.M31;
         var offsetY = _matrix.M32;
 
+        
+        var padding = BoundsPadding;
+
+        // The actual visual position is: layoutOffset + matrix offset
+        // So: matrix offset = desired position - layoutOffset
+
         // If content is smaller than viewport, center it
         if (contentWidth <= viewportWidth)
         {
-            offsetX = (viewportWidth - contentWidth) / 2.0;
+            var centeredX = (viewportWidth - contentWidth) / 2.0;
+            offsetX = centeredX - layoutOffset.X;
         }
         else
         {
-            // Constrain so no empty space is visible
-            offsetX = ClampValue(offsetX, viewportWidth - contentWidth, 0);
+            // Constrain so no empty space is visible (with padding)
+            // Visual position range should be: [viewportWidth - contentWidth - padding.Left, padding.Right]
+            // So matrix offset range is: visual range shifted by -layoutOffset.X
+            offsetX = ClampValue(offsetX, viewportWidth - contentWidth - padding.Left - layoutOffset.X, padding.Right - layoutOffset.X);
         }
 
         if (contentHeight <= viewportHeight)
         {
-            offsetY = (viewportHeight - contentHeight) / 2.0;
+            var centeredY = (viewportHeight - contentHeight) / 2.0;
+            offsetY = centeredY - layoutOffset.Y;
         }
         else
         {
-            // Constrain so no empty space is visible
-            offsetY = ClampValue(offsetY, viewportHeight - contentHeight, 0);
+            // Constrain so no empty space is visible (with padding)
+            // Visual position range should be: [viewportHeight - contentHeight - padding.Top, padding.Bottom]
+            // So matrix offset range is: visual range shifted by -layoutOffset.Y
+            offsetY = ClampValue(offsetY, viewportHeight - contentHeight - padding.Top - layoutOffset.Y, padding.Bottom - layoutOffset.Y);
         }
 
         _matrix = new Matrix(_matrix.M11, 0.0, 0.0, _matrix.M22, offsetX, offsetY);
@@ -1941,13 +1999,22 @@ public partial class ZoomBorder : Border
         if (_element == null)
             return;
 
+        // Get the layout offset where Avalonia positioned the element
+        var layoutOffset = _element.Bounds.Position;
+        
         var contentWidth = _element.Bounds.Width * _matrix.M11;
         var contentHeight = _element.Bounds.Height * _matrix.M22;
         var viewportWidth = Bounds.Width;
         var viewportHeight = Bounds.Height;
 
-        var offsetX = (viewportWidth - contentWidth) / 2.0;
-        var offsetY = (viewportHeight - contentHeight) / 2.0;
+        // Calculate where the content should be centered in viewport coordinates
+        var centeredX = (viewportWidth - contentWidth) / 2.0;
+        var centeredY = (viewportHeight - contentHeight) / 2.0;
+        
+        // The actual visual position is: layoutOffset + matrix offset
+        // So: matrix offset = desired position - layoutOffset
+        var offsetX = centeredX - layoutOffset.X;
+        var offsetY = centeredY - layoutOffset.Y;
 
         _matrix = new Matrix(_matrix.M11, 0.0, 0.0, _matrix.M22, offsetX, offsetY);
     }

--- a/src/PanAndZoom/ZoomBorder.cs
+++ b/src/PanAndZoom/ZoomBorder.cs
@@ -85,6 +85,14 @@ public partial class ZoomBorder : Border
     private bool _zoomIndicatorVisible;
 
     /// <summary>
+    /// Gets the layout offset where Avalonia positioned the child element within this ZoomBorder.
+    /// When a child element is smaller than the ZoomBorder, Avalonia centers it, resulting in a
+    /// non-zero Bounds.Position. This offset is in viewport coordinates and should NOT be scaled
+    /// by the transform matrix when converting between coordinate systems.
+    /// </summary>
+    private Point LayoutOffset => _element?.Bounds.Position ?? default;
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="ZoomBorder"/> class.
     /// </summary>
     public ZoomBorder()
@@ -997,8 +1005,7 @@ public partial class ZoomBorder : Border
         if (_element == null)
             return;
 
-        // Get the layout offset where Avalonia positioned the element
-        var layoutOffset = _element.Bounds.Position;
+        var layoutOffset = LayoutOffset;
 
         var viewportCenterX = (Bounds.Width - CenterPadding.Left - CenterPadding.Right) / 2.0 + CenterPadding.Left;
         var viewportCenterY = (Bounds.Height - CenterPadding.Top - CenterPadding.Bottom) / 2.0 + CenterPadding.Top;
@@ -1022,8 +1029,7 @@ public partial class ZoomBorder : Border
         if (_element == null)
             return;
 
-        // Get the layout offset where Avalonia positioned the element
-        var layoutOffset = _element.Bounds.Position;
+        var layoutOffset = LayoutOffset;
 
         var viewportCenterX = (Bounds.Width - CenterPadding.Left - CenterPadding.Right) / 2.0 + CenterPadding.Left;
         var viewportCenterY = (Bounds.Height - CenterPadding.Top - CenterPadding.Bottom) / 2.0 + CenterPadding.Top;
@@ -1084,9 +1090,7 @@ public partial class ZoomBorder : Border
         if (!_matrix.TryInvert(out var inverted))
             return viewportPoint;
 
-        // Account for layout offset: viewport coordinates need to be adjusted
-        // before applying the inverse matrix transform
-        var layoutOffset = _element?.Bounds.Position ?? new Point(0, 0);
+        var layoutOffset = LayoutOffset;
         var adjustedPoint = new Point(viewportPoint.X - layoutOffset.X, viewportPoint.Y - layoutOffset.Y);
 
         return inverted.Transform(adjustedPoint);
@@ -1101,8 +1105,7 @@ public partial class ZoomBorder : Border
     {
         var transformed = _matrix.Transform(contentPoint);
 
-        // Account for layout offset: add it after the matrix transform
-        var layoutOffset = _element?.Bounds.Position ?? new Point(0, 0);
+        var layoutOffset = LayoutOffset;
         return new Point(transformed.X + layoutOffset.X, transformed.Y + layoutOffset.Y);
     }
 
@@ -1116,9 +1119,7 @@ public partial class ZoomBorder : Border
         if (!_matrix.TryInvert(out var inverted))
             return viewportRect;
 
-        // Account for layout offset: viewport coordinates need to be adjusted
-        // before applying the inverse matrix transform
-        var layoutOffset = _element?.Bounds.Position ?? new Point(0, 0);
+        var layoutOffset = LayoutOffset;
         var adjustedRect = new Rect(
             viewportRect.X - layoutOffset.X,
             viewportRect.Y - layoutOffset.Y,
@@ -1141,8 +1142,7 @@ public partial class ZoomBorder : Border
         var topLeft = _matrix.Transform(contentRect.TopLeft);
         var bottomRight = _matrix.Transform(contentRect.BottomRight);
 
-        // Account for layout offset: add it after the matrix transform
-        var layoutOffset = _element?.Bounds.Position ?? new Point(0, 0);
+        var layoutOffset = LayoutOffset;
         return new Rect(
             topLeft.X + layoutOffset.X,
             topLeft.Y + layoutOffset.Y,
@@ -1251,8 +1251,7 @@ public partial class ZoomBorder : Border
             return;
         _updating = true;
 
-        // Get the layout offset where Avalonia positioned the element
-        var layoutOffset = _element.Bounds.Position;
+        var layoutOffset = LayoutOffset;
 
         var pad = padding ?? new Thickness(0);
         var viewportWidth = Bounds.Width - pad.Left - pad.Right;
@@ -1309,8 +1308,7 @@ public partial class ZoomBorder : Border
             return;
         _updating = true;
 
-        // Get the layout offset where Avalonia positioned the element
-        var layoutOffset = _element.Bounds.Position;
+        var layoutOffset = LayoutOffset;
 
         var zoomX = viewportRect.Width / rect.Width;
         var zoomY = viewportRect.Height / rect.Height;
@@ -1905,8 +1903,7 @@ public partial class ZoomBorder : Border
         if (_element == null)
             return;
 
-        // Get the layout offset where Avalonia positioned the element
-        var layoutOffset = _element.Bounds.Position;
+        var layoutOffset = LayoutOffset;
 
         var contentWidth = _element.Bounds.Width * _matrix.M11;
         var contentHeight = _element.Bounds.Height * _matrix.M22;
@@ -1947,8 +1944,7 @@ public partial class ZoomBorder : Border
         if (_element == null)
             return;
 
-        // Get the layout offset where Avalonia positioned the element
-        var layoutOffset = _element.Bounds.Position;
+        var layoutOffset = LayoutOffset;
 
         var contentWidth = _element.Bounds.Width * _matrix.M11;
         var contentHeight = _element.Bounds.Height * _matrix.M22;
@@ -1999,8 +1995,7 @@ public partial class ZoomBorder : Border
         if (_element == null)
             return;
 
-        // Get the layout offset where Avalonia positioned the element
-        var layoutOffset = _element.Bounds.Position;
+        var layoutOffset = LayoutOffset;
         
         var contentWidth = _element.Bounds.Width * _matrix.M11;
         var contentHeight = _element.Bounds.Height * _matrix.M22;

--- a/tests/Avalonia.Controls.PanAndZoom.UnitTests/ZoomBorderNonZeroLayoutOffsetTests.cs
+++ b/tests/Avalonia.Controls.PanAndZoom.UnitTests/ZoomBorderNonZeroLayoutOffsetTests.cs
@@ -1,0 +1,584 @@
+﻿using Avalonia.Controls.Primitives;
+using Avalonia.Headless.XUnit;
+using Avalonia.Media;
+using Xunit;
+
+namespace Avalonia.Controls.PanAndZoom.UnitTests;
+
+/// <summary>
+/// Tests for ZoomBorder behavior when the child element is smaller than the ZoomBorder,
+/// resulting in Avalonia centering the child with a non-zero Bounds.Position (layout offset).
+/// 
+/// These tests validate fixes for the issue where code assumed child.Bounds.Position == (0, 0).
+/// </summary>
+public class ZoomBorderNonZeroLayoutOffsetTests
+{
+    #region Layout Offset Verification
+    
+    [AvaloniaFact]
+    public void ChildSmallerThanZoomBorder_IsCenteredByAvalonia()
+    {
+        // Arrange - Create ZoomBorder larger than its child
+        var zoomBorder = new ZoomBorder
+        {
+            Width = 600,
+            Height = 400
+        };
+
+        var childElement = new Border
+        {
+            Width = 200,
+            Height = 100,
+            Background = Brushes.Yellow
+        };
+
+        zoomBorder.Child = childElement;
+        var window = new Window { Content = zoomBorder };
+        window.Show();
+
+        // Assert - Avalonia should center the child, creating a non-zero Position
+        var expectedOffsetX = (600 - 200) / 2.0; // 200
+        var expectedOffsetY = (400 - 100) / 2.0; // 150
+        
+        Assert.Equal(expectedOffsetX, childElement.Bounds.X, 1);
+        Assert.Equal(expectedOffsetY, childElement.Bounds.Y, 1);
+    }
+
+    [AvaloniaFact]
+    public void ChildLargerThanZoomBorder_HasNegativeLayoutOffset()
+    {
+        // Arrange - Child larger than ZoomBorder (still gets centered)
+        var zoomBorder = new ZoomBorder
+        {
+            Width = 400,
+            Height = 300
+        };
+
+        var childElement = new Border
+        {
+            Width = 600,
+            Height = 500,
+            Background = Brushes.Yellow
+        };
+
+        zoomBorder.Child = childElement;
+        var window = new Window { Content = zoomBorder };
+        window.Show();
+
+        // Assert - Child is centered, so Position will be negative
+        var expectedOffsetX = (400 - 600) / 2.0; // -100
+        var expectedOffsetY = (300 - 500) / 2.0; // -100
+        
+        Assert.Equal(expectedOffsetX, childElement.Bounds.X, 1);
+        Assert.Equal(expectedOffsetY, childElement.Bounds.Y, 1);
+    }
+
+    #endregion
+
+    #region TransformContentToViewport Helper Tests
+    
+    [Fact]
+    public void TransformContentToViewport_LayoutOffsetAddedAfterTransform()
+    {
+        // Arrange - Element bounds with non-zero position (as if centered by layout)
+        var elementBounds = new Rect(100, 50, 200, 150); // Position (100, 50), Size (200, 150)
+        var matrix = Matrix.Identity;
+        
+        // Act
+        var result = ZoomBorder.TransformContentToViewport(elementBounds, matrix);
+        
+        // Assert - With identity matrix, content at (0,0) + layout offset (100,50) = (100, 50)
+        Assert.Equal(100, result.X, 1);
+        Assert.Equal(50, result.Y, 1);
+        Assert.Equal(200, result.Width, 1);
+        Assert.Equal(150, result.Height, 1);
+    }
+
+    [Fact]
+    public void TransformContentToViewport_LayoutOffsetNotScaledByZoom()
+    {
+        // Arrange
+        var elementBounds = new Rect(100, 50, 200, 150);
+        var matrix = new Matrix(2, 0, 0, 2, 0, 0); // 2x zoom, no pan
+        
+        // Act
+        var result = ZoomBorder.TransformContentToViewport(elementBounds, matrix);
+        
+        // Assert - Content size scaled 2x, but layout offset NOT scaled
+        // Content (0,0) transformed = (0,0), then + layout offset = (100, 50)
+        // Size (200, 150) * 2 = (400, 300)
+        Assert.Equal(100, result.X, 1);
+        Assert.Equal(50, result.Y, 1);
+        Assert.Equal(400, result.Width, 1);
+        Assert.Equal(300, result.Height, 1);
+    }
+
+    [Fact]
+    public void TransformContentToViewport_WithContentRectOverload_WorksCorrectly()
+    {
+        // Arrange - A region inside the content, not at origin
+        var contentRect = new Rect(50, 25, 100, 75); // Region at (50, 25) within content
+        var layoutOffset = new Point(100, 50);
+        var matrix = new Matrix(2, 0, 0, 2, 0, 0); // 2x zoom
+        
+        // Act
+        var result = ZoomBorder.TransformContentToViewport(contentRect, layoutOffset, matrix);
+        
+        // Assert
+        // Content point (50, 25) * 2 = (100, 50), then + layout offset (100, 50) = (200, 100)
+        // Size (100, 75) * 2 = (200, 150)
+        Assert.Equal(200, result.X, 1);
+        Assert.Equal(100, result.Y, 1);
+        Assert.Equal(200, result.Width, 1);
+        Assert.Equal(150, result.Height, 1);
+    }
+
+    #endregion
+
+    #region CalculateScrollable Tests with Non-Zero Layout Offset
+
+    [Fact]
+    public void CalculateScrollable_WithNonZeroLayoutOffset_CorrectExtent()
+    {
+        // Arrange - Child centered within larger ZoomBorder
+        var borderSize = new Size(600, 400);
+        var bounds = new Rect(200, 150, 200, 100); // Centered: position (200, 150), size (200, 100)
+        var matrix = Matrix.Identity;
+        
+        // Act
+        ZoomBorder.CalculateScrollable(bounds, borderSize, matrix, out var extent, out var viewport, out var offset);
+        
+        // Assert - Content fits within viewport at its centered position
+        Assert.Equal(new Size(600, 400), extent); // Extent matches viewport when content fits
+        Assert.Equal(new Size(600, 400), viewport);
+        Assert.Equal(new Vector(0, 0), offset);
+    }
+
+    [Fact]
+    public void CalculateScrollable_WithNonZeroLayoutOffset_Zoomed2x()
+    {
+        // Arrange - Child centered, then zoomed
+        var borderSize = new Size(600, 400);
+        var bounds = new Rect(200, 150, 200, 100); // Centered child
+        var matrix = new Matrix(2, 0, 0, 2, 0, 0); // 2x zoom at origin
+        
+        // Act
+        ZoomBorder.CalculateScrollable(bounds, borderSize, matrix, out var extent, out var viewport, out var offset);
+        
+        // Assert
+        // Content size: 200*2 = 400, 100*2 = 200
+        // Content visual position: layout offset (200, 150) + transform origin (0, 0) = (200, 150)
+        // This means content still starts at (200, 150) in viewport, extending to (600, 350)
+        Assert.Equal(new Size(600, 400), viewport);
+        Assert.Equal(new Size(600, 400), extent); // Still fits in viewport
+        Assert.Equal(new Vector(0, 0), offset); // No scrolling needed
+    }
+
+    [Fact]
+    public void CalculateScrollable_WithNonZeroLayoutOffset_PannedNegative()
+    {
+        // Arrange
+        var borderSize = new Size(600, 400);
+        var bounds = new Rect(200, 150, 200, 100); // Centered child
+        var matrix = new Matrix(1, 0, 0, 1, -300, -200); // Panned left and up
+        
+        // Act
+        ZoomBorder.CalculateScrollable(bounds, borderSize, matrix, out var extent, out var viewport, out var offset);
+        
+        // Assert - Content visual position = layout offset + matrix offset = (200-300, 150-200) = (-100, -50)
+        // With negative position, extent grows and offset tracks how far content is scrolled
+        Assert.Equal(new Size(600, 400), viewport);
+        Assert.True(extent.Width >= viewport.Width, "Extent should accommodate scrollable range");
+        Assert.True(offset.X > 0, "Should have positive X scroll offset when content is left of viewport");
+        Assert.True(offset.Y > 0, "Should have positive Y scroll offset when content is above viewport");
+    }
+
+    #endregion
+
+    #region Coordinate Conversion Tests with Centered Child
+
+    [AvaloniaFact]
+    public void ViewportToContent_CenteredChild_CorrectConversion()
+    {
+        // Arrange - Use StretchMode.None to avoid automatic zoom adjustments
+        var zoomBorder = new ZoomBorder
+        {
+            Width = 600,
+            Height = 400,
+            Stretch = StretchMode.None
+        };
+
+        var childElement = new Border
+        {
+            Width = 200,
+            Height = 100,
+            Background = Brushes.Yellow
+        };
+
+        zoomBorder.Child = childElement;
+        var window = new Window { Content = zoomBorder };
+        window.Show();
+
+        // Layout offset should be (200, 150) since child is centered
+        var layoutOffsetX = (600 - 200) / 2.0;
+        var layoutOffsetY = (400 - 100) / 2.0;
+        
+        // Act - Convert viewport point at layout offset to content
+        var contentPoint = zoomBorder.ViewportToContent(new Point(layoutOffsetX, layoutOffsetY));
+        
+        // Assert - Viewport point at layout offset should map to content origin (0, 0)
+        Assert.Equal(0, contentPoint.X, 1);
+        Assert.Equal(0, contentPoint.Y, 1);
+    }
+
+    [AvaloniaFact]
+    public void ContentToViewport_CenteredChild_CorrectConversion()
+    {
+        // Arrange - Use StretchMode.None to avoid automatic zoom adjustments
+        var zoomBorder = new ZoomBorder
+        {
+            Width = 600,
+            Height = 400,
+            Stretch = StretchMode.None
+        };
+
+        var childElement = new Border
+        {
+            Width = 200,
+            Height = 100,
+            Background = Brushes.Yellow
+        };
+
+        zoomBorder.Child = childElement;
+        var window = new Window { Content = zoomBorder };
+        window.Show();
+
+        var expectedLayoutOffsetX = (600 - 200) / 2.0; // 200
+        var expectedLayoutOffsetY = (400 - 100) / 2.0; // 150
+        
+        // Act - Convert content origin (0, 0) to viewport
+        var viewportPoint = zoomBorder.ContentToViewport(new Point(0, 0));
+        
+        // Assert - Content origin should map to layout offset position
+        Assert.Equal(expectedLayoutOffsetX, viewportPoint.X, 1);
+        Assert.Equal(expectedLayoutOffsetY, viewportPoint.Y, 1);
+    }
+
+    [AvaloniaFact]
+    public void ViewportToContent_RoundTrip_CenteredChild_PreservesPoint()
+    {
+        // Arrange
+        var zoomBorder = new ZoomBorder
+        {
+            Width = 600,
+            Height = 400
+        };
+
+        var childElement = new Border
+        {
+            Width = 200,
+            Height = 100,
+            Background = Brushes.Yellow
+        };
+
+        zoomBorder.Child = childElement;
+        var window = new Window { Content = zoomBorder };
+        window.Show();
+
+        zoomBorder.Zoom(1.5, 100, 50); // Zoom at a point within content
+
+        var originalViewportPoint = new Point(350, 220);
+        
+        // Act
+        var contentPoint = zoomBorder.ViewportToContent(originalViewportPoint);
+        var roundTrippedPoint = zoomBorder.ContentToViewport(contentPoint);
+        
+        // Assert
+        Assert.Equal(originalViewportPoint.X, roundTrippedPoint.X, 1);
+        Assert.Equal(originalViewportPoint.Y, roundTrippedPoint.Y, 1);
+    }
+
+    #endregion
+
+    #region CenterOn Tests with Centered Child
+
+    [AvaloniaFact]
+    public void CenterOn_Point_CenteredChild_PointIsCenteredInViewport()
+    {
+        // Arrange
+        var zoomBorder = new ZoomBorder
+        {
+            Width = 600,
+            Height = 400
+        };
+
+        var childElement = new Border
+        {
+            Width = 200,
+            Height = 100,
+            Background = Brushes.Yellow
+        };
+
+        zoomBorder.Child = childElement;
+        var window = new Window { Content = zoomBorder };
+        window.Show();
+
+        var targetContentPoint = new Point(100, 50); // Center of the content
+        
+        // Act
+        zoomBorder.CenterOn(targetContentPoint, animate: false);
+        
+        // Assert - Target point should now be at viewport center
+        var viewportCenter = new Point(300, 200);
+        var transformedPoint = zoomBorder.ContentToViewport(targetContentPoint);
+        
+        Assert.Equal(viewportCenter.X, transformedPoint.X, 1);
+        Assert.Equal(viewportCenter.Y, transformedPoint.Y, 1);
+    }
+
+    [AvaloniaFact]
+    public void CenterOn_PointWithZoom_CenteredChild_CorrectPositionAndZoom()
+    {
+        // Arrange
+        var zoomBorder = new ZoomBorder
+        {
+            Width = 600,
+            Height = 400
+        };
+
+        var childElement = new Border
+        {
+            Width = 200,
+            Height = 100,
+            Background = Brushes.Yellow
+        };
+
+        zoomBorder.Child = childElement;
+        var window = new Window { Content = zoomBorder };
+        window.Show();
+
+        var targetContentPoint = new Point(50, 25);
+        var targetZoom = 2.0;
+        
+        // Act
+        zoomBorder.CenterOn(targetContentPoint, targetZoom, animate: false);
+        
+        // Assert
+        Assert.Equal(targetZoom, zoomBorder.ZoomX, 2);
+        Assert.Equal(targetZoom, zoomBorder.ZoomY, 2);
+        
+        // Target point should be at viewport center
+        var viewportCenter = new Point(300, 200);
+        var transformedPoint = zoomBorder.ContentToViewport(targetContentPoint);
+        
+        Assert.Equal(viewportCenter.X, transformedPoint.X, 1);
+        Assert.Equal(viewportCenter.Y, transformedPoint.Y, 1);
+    }
+
+    #endregion
+
+    #region ZoomToRectangle Tests with Centered Child
+
+    [AvaloniaFact]
+    public void ZoomToRectangle_CenteredChild_RectangleCenteredInViewport()
+    {
+        // Arrange
+        var zoomBorder = new ZoomBorder
+        {
+            Width = 600,
+            Height = 400
+        };
+
+        var childElement = new Border
+        {
+            Width = 200,
+            Height = 100,
+            Background = Brushes.Yellow
+        };
+
+        zoomBorder.Child = childElement;
+        var window = new Window { Content = zoomBorder };
+        window.Show();
+
+        var targetRect = new Rect(25, 10, 100, 60); // A sub-region of the content
+        
+        // Act
+        zoomBorder.ZoomToRectangle(targetRect);
+        
+        // Assert - The center of the target rect should be at viewport center
+        var rectCenter = new Point(targetRect.X + targetRect.Width / 2.0, 
+                                   targetRect.Y + targetRect.Height / 2.0);
+        var viewportCenter = new Point(300, 200);
+        var transformedCenter = zoomBorder.ContentToViewport(rectCenter);
+        
+        Assert.Equal(viewportCenter.X, transformedCenter.X, 1);
+        Assert.Equal(viewportCenter.Y, transformedCenter.Y, 1);
+    }
+
+    #endregion
+
+    #region Content Bounds Restriction Tests with Centered Child
+
+    [AvaloniaFact]
+    public void KeepContentVisible_CenteredChild_ConstrainsCorrectly()
+    {
+        // Arrange
+        var zoomBorder = new ZoomBorder
+        {
+            Width = 600,
+            Height = 400,
+            BoundsMode = ContentBoundsMode.KeepContentVisible,
+            MinimumVisibleContentPercentage = 0.1,
+            EnableConstrains = true
+        };
+
+        var childElement = new Border
+        {
+            Width = 200,
+            Height = 100,
+            Background = Brushes.Yellow
+        };
+
+        zoomBorder.Child = childElement;
+        var window = new Window { Content = zoomBorder };
+        window.Show();
+        
+        // Act - Try to pan way off screen
+        zoomBorder.Pan(5000, 5000);
+        
+        // Assert - Should be constrained, not at (5000, 5000)
+        Assert.True(zoomBorder.OffsetX < 5000, "OffsetX should be constrained");
+        Assert.True(zoomBorder.OffsetY < 5000, "OffsetY should be constrained");
+        
+        // Content should still have some portion visible (per MinimumVisibleContentPercentage)
+        var contentVisualBounds = zoomBorder.ContentToViewport(new Rect(0, 0, 200, 100));
+        
+        // Check that content hasn't completely left the viewport
+        Assert.True(contentVisualBounds.Right > 0 || contentVisualBounds.Bottom > 0 || 
+                    contentVisualBounds.Left < 600 || contentVisualBounds.Top < 400,
+                    "Content should still be at least partially visible");
+    }
+
+    [AvaloniaFact]
+    public void KeepCentered_CenteredChild_MaintainsCenter()
+    {
+        // Arrange
+        var zoomBorder = new ZoomBorder
+        {
+            Width = 600,
+            Height = 400,
+            BoundsMode = ContentBoundsMode.KeepCentered,
+            EnableConstrains = true
+        };
+
+        var childElement = new Border
+        {
+            Width = 200,
+            Height = 100,
+            Background = Brushes.Yellow
+        };
+
+        zoomBorder.Child = childElement;
+        var window = new Window { Content = zoomBorder };
+        window.Show();
+
+        // Act - Try to pan
+        zoomBorder.Pan(500, 500);
+        
+        // Assert - Content should remain centered
+        // Content center (100, 50) should map to viewport center (300, 200)
+        var contentCenter = new Point(100, 50);
+        var transformedCenter = zoomBorder.ContentToViewport(contentCenter);
+        
+        // With KeepCentered, after any pan attempt the content should be re-centered
+        Assert.Equal(300, transformedCenter.X, 1);
+        Assert.Equal(200, transformedCenter.Y, 1);
+    }
+
+    #endregion
+
+    #region BringIntoView Tests with Centered Child
+
+    [AvaloniaFact]
+    public void BringIntoView_CenteredChild_AlreadyVisible_NoPositionChange()
+    {
+        // Arrange
+        var zoomBorder = new ZoomBorder
+        {
+            Width = 600,
+            Height = 400
+        };
+
+        var childElement = new Border
+        {
+            Width = 200,
+            Height = 100,
+            Background = Brushes.Yellow
+        };
+
+        zoomBorder.Child = childElement;
+        var window = new Window { Content = zoomBorder };
+        window.Show();
+
+        var initialOffsetX = zoomBorder.OffsetX;
+        var initialOffsetY = zoomBorder.OffsetY;
+        var initialZoomX = zoomBorder.ZoomX;
+        var initialZoomY = zoomBorder.ZoomY;
+        
+        var scrollable = (ILogicalScrollable)zoomBorder;
+        
+        // Act - BringIntoView on the child itself (which is fully visible since it's smaller than viewport)
+        var result = scrollable.BringIntoView(childElement, new Rect(0, 0, 200, 100));
+        
+        // Assert - Should return true but NOT change position since already visible
+        Assert.True(result);
+        Assert.Equal(initialOffsetX, zoomBorder.OffsetX, 1);
+        Assert.Equal(initialOffsetY, zoomBorder.OffsetY, 1);
+        Assert.Equal(initialZoomX, zoomBorder.ZoomX, 3);
+        Assert.Equal(initialZoomY, zoomBorder.ZoomY, 3);
+    }
+
+    [AvaloniaFact]
+    public void BringIntoView_CenteredChild_AfterPanning_ScrollsToTarget()
+    {
+        // Arrange
+        var zoomBorder = new ZoomBorder
+        {
+            Width = 600,
+            Height = 400,
+            BoundsMode = ContentBoundsMode.Unrestricted // Allow unrestricted panning
+        };
+
+        var childElement = new Border
+        {
+            Width = 200,
+            Height = 100,
+            Background = Brushes.Yellow
+        };
+
+        zoomBorder.Child = childElement;
+        var window = new Window { Content = zoomBorder };
+        window.Show();
+
+        // Pan content off screen
+        zoomBorder.Pan(-800, -600);
+        
+        var scrollable = (ILogicalScrollable)zoomBorder;
+        
+        // Act - Request to bring content region into view
+        var result = scrollable.BringIntoView(childElement, new Rect(0, 0, 50, 30));
+        
+        // Assert - Should succeed and adjust pan to make the target visible
+        Assert.True(result);
+        
+        // Verify the target region is now at least partially visible
+        var targetInViewport = zoomBorder.ContentToViewport(new Rect(0, 0, 50, 30));
+        var viewportBounds = new Rect(0, 0, 600, 400);
+        
+        // The target rect should now intersect with the viewport
+        Assert.True(viewportBounds.Intersects(targetInViewport), 
+            "Target region should be visible in viewport after BringIntoView");
+    }
+
+    #endregion
+}

--- a/tests/Avalonia.Controls.PanAndZoom.UnitTests/ZoomBorderZoomToRectangleTests.cs
+++ b/tests/Avalonia.Controls.PanAndZoom.UnitTests/ZoomBorderZoomToRectangleTests.cs
@@ -100,13 +100,16 @@ public class ZoomBorderZoomToRectangleTests
         var rect = new Rect(50, 100, 200, 150);
         
         // Expected calculations:
+        // Layout offset: Border always centers its child, so layoutOffset = ((600-800)/2, (400-600)/2) = (-100, -100)
         // zoom = min(600/200, 400/150) = min(3, 2.667) = 2.667
         // rectCenterX = 50 + 100 = 150
         // rectCenterY = 100 + 75 = 175
         // viewportCenterX = 300
         // viewportCenterY = 200
-        // offsetX = 300 - 150 * 2.667 = 300 - 400 = -100
-        // offsetY = 200 - 175 * 2.667 = 200 - 466.67 = -266.67
+        // The visual position formula is: visualPos = layoutOffset + matrixOffset + contentPoint * zoom
+        // So: matrixOffset = viewportCenter - layoutOffset - contentPoint * zoom
+        // offsetX = 300 - (-100) - 150 * 2.667 = 400 - 400 = 0
+        // offsetY = 200 - (-100) - 175 * 2.667 = 300 - 466.67 = -166.67
 
         // Act
         zoomBorder.ZoomToRectangle(rect);
@@ -115,16 +118,23 @@ public class ZoomBorderZoomToRectangleTests
         var expectedZoom = Math.Min(600.0 / 200.0, 400.0 / 150.0);
         var rectCenterX = rect.X + rect.Width / 2.0;
         var rectCenterY = rect.Y + rect.Height / 2.0;
-        var expectedOffsetX = 300.0 - rectCenterX * expectedZoom;
-        var expectedOffsetY = 200.0 - rectCenterY * expectedZoom;
+        
+        // Layout offset where Avalonia centers the child within the ZoomBorder
+        var layoutOffsetX = (600.0 - 800.0) / 2.0;  // -100
+        var layoutOffsetY = (400.0 - 600.0) / 2.0;  // -100
+        
+        // Matrix offset = viewportCenter - layoutOffset - contentCenter * zoom
+        var expectedOffsetX = 300.0 - layoutOffsetX - rectCenterX * expectedZoom;
+        var expectedOffsetY = 200.0 - layoutOffsetY - rectCenterY * expectedZoom;
 
         Assert.Equal(expectedZoom, zoomBorder.ZoomX, 2);
         Assert.Equal(expectedOffsetX, zoomBorder.OffsetX, 2);
         Assert.Equal(expectedOffsetY, zoomBorder.OffsetY, 2);
         
         // Verify that the rectangle center point transforms to viewport center
-        var transformedCenterX = rectCenterX * zoomBorder.ZoomX + zoomBorder.OffsetX;
-        var transformedCenterY = rectCenterY * zoomBorder.ZoomY + zoomBorder.OffsetY;
+        // Visual position = layoutOffset + matrixOffset + contentPoint * zoom
+        var transformedCenterX = layoutOffsetX + rectCenterX * zoomBorder.ZoomX + zoomBorder.OffsetX;
+        var transformedCenterY = layoutOffsetY + rectCenterY * zoomBorder.ZoomY + zoomBorder.OffsetY;
         
         Assert.Equal(300.0, transformedCenterX, 1);
         Assert.Equal(200.0, transformedCenterY, 1);


### PR DESCRIPTION
The code consistently assumes that the child element's position within the ZoomBorder is at (0, 0), but this is only true when the child fills the ZoomBorder exactly. When the child is smaller (has a fixed size), Avalonia's default layout system centers it, resulting in the child having a non-zero Position offset within its Bounds rectangle.

This PR tries to fix a whole bunch of issues that show up the moment the position of _element isn't (0,0). It starts with the CalculateScrollable method that calculates the bounds for a scrollviewer. With this PR, the scrollviewer now correctly works even when _element has a non zero position. 

Whenever the zoomborder regained mouse focus, the BringIntoView method is called. for _element with non zero position, this would trigger a position jump by the LayoutOffset. This is also fixed. 

All affected methods: 

| Method | File | Status |
|--------|------|--------|
| `CalculateScrollable` | ILogicalScrollable.cs | Now uses `TransformContentToViewport` helper |
| `BringIntoView` | ILogicalScrollable.cs |  Now uses `TransformContentToViewport` helper |
| `IScrollable.Offset setter` | ILogicalScrollable.cs | Works correctly now that `CalculateScrollable` is fixed |
| `ApplyKeepContentVisible` | ZoomBorder.cs | Now accounts for layout offset in constraints |
| `ApplyFillViewport` | ZoomBorder.cs | Now accounts for layout offset; added BoundsPadding support |
| `ApplyKeepCentered` | ZoomBorder.cs |  Now accounts for layout offset in centering |
| `CenterOn(Point, bool)` | ZoomBorder.cs | Now accounts for layout offset |
| `CenterOn(Point, double, bool)` | ZoomBorder.cs | Now accounts for layout offset |
| `CenterOn(Rect, bool)` | ZoomBorder.cs | Delegates to fixed `CenterOn(Point, double, bool)` |
| `CenterOn(Control, bool)` | ZoomBorder.cs | Delegates to fixed `CenterOn(Rect, bool)` |
| `ZoomToRectangle` | ZoomBorder.cs | Now accounts for layout offset |
| `ZoomToRectangleExact` | ZoomBorder.cs | Now accounts for layout offset |
| `ViewportToContent(Point)` | ZoomBorder.cs | Now subtracts layout offset before inverse transform |
| `ViewportToContent(Rect)` | ZoomBorder.cs | Now subtracts layout offset before inverse transform |
| `ContentToViewport(Point)` | ZoomBorder.cs | Now adds layout offset after transform |
| `ContentToViewport(Rect)` | ZoomBorder.cs | Now adds layout offset after transform |

There are still a few methods that might need updating that I didn't update yet, because there wasn't a good way for me to test the new functionality. As far as I can tell, they are all part of ResizeBehavior. Testing of this behavior wasn't possible for me due to #130 . 


I added an extra test file to specifically test for the new behavior. All tests pass successfully.

This PR fixes #132 

I am aware that this is a rather large change to the codebase. In a comment in #132 I described a potential alternative fix that would be pretty minimal. We would loose the default layout handling that currently still works though, meaning that we couldn't use VerticalAlignment/HorizontalAlignment on the child component anymore. I am unsure which approach would align better with your goals for PanAndZoom, if you want I can also prepare a PR for the other approach if you don't like this change.

