### PR TITLE
Upgrade PanAndZoom to Avalonia 12.0.0

### DIFF
--- a/build/Avalonia.Desktop.props
+++ b/build/Avalonia.Desktop.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Avalonia.Desktop" Version="12.0.0-rc1" />
+    <PackageReference Include="Avalonia.Desktop" Version="12.0.0" />
   </ItemGroup>
 </Project>

--- a/build/Avalonia.Desktop.props
+++ b/build/Avalonia.Desktop.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Avalonia.Desktop" Version="11.3.9" />
+    <PackageReference Include="Avalonia.Desktop" Version="12.0.0-rc1" />
   </ItemGroup>
 </Project>

--- a/build/Avalonia.Diagnostics.props
+++ b/build/Avalonia.Diagnostics.props
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup>
-    <PackageReference Include="Avalonia.Diagnostics" Version="11.3.9" />
-  </ItemGroup>
-</Project>

--- a/build/Avalonia.Diagnostics.props
+++ b/build/Avalonia.Diagnostics.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Avalonia.Browser" Version="12.0.0" />
+    <PackageReference Include="ProDiagnostics" Version="12.0.0" />
   </ItemGroup>
 </Project>

--- a/build/Avalonia.Headless.props
+++ b/build/Avalonia.Headless.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Avalonia.Headless" Version="12.0.0-rc1" />
+    <PackageReference Include="Avalonia.Headless" Version="12.0.0" />
   </ItemGroup>
 </Project>

--- a/build/Avalonia.Headless.props
+++ b/build/Avalonia.Headless.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Avalonia.Headless" Version="11.3.9" />
+    <PackageReference Include="Avalonia.Headless" Version="12.0.0-rc1" />
   </ItemGroup>
 </Project>

--- a/build/Avalonia.Themes.Fluent.props
+++ b/build/Avalonia.Themes.Fluent.props
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.0-rc1" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.0-rc1" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.0" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.0" />
   </ItemGroup>
 </Project>

--- a/build/Avalonia.Themes.Fluent.props
+++ b/build/Avalonia.Themes.Fluent.props
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.9" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.9" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.0-rc1" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.0-rc1" />
   </ItemGroup>
 </Project>

--- a/build/Avalonia.Web.props
+++ b/build/Avalonia.Web.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Avalonia.Browser" Version="11.3.9" />
+    <PackageReference Include="Avalonia.Browser" Version="12.0.0-rc1" />
   </ItemGroup>
 </Project>

--- a/build/Avalonia.props
+++ b/build/Avalonia.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.3.9" />
+    <PackageReference Include="Avalonia" Version="12.0.0-rc1" />
   </ItemGroup>
 </Project>

--- a/build/Avalonia.props
+++ b/build/Avalonia.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="12.0.0-rc1" />
+    <PackageReference Include="Avalonia" Version="12.0.0" />
   </ItemGroup>
 </Project>

--- a/build/Base.props
+++ b/build/Base.props
@@ -1,7 +1,7 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <VersionPrefix>11.3.9.1</VersionPrefix>
-    <VersionSuffix></VersionSuffix>
+    <VersionPrefix>12.0.0</VersionPrefix>
+    <VersionSuffix>rc1</VersionSuffix>
     <Authors>Wiesław Šoltés</Authors>
     <Company>Wiesław Šoltés</Company>
     <Copyright>Copyright © Wiesław Šoltés 2025</Copyright>

--- a/build/Base.props
+++ b/build/Base.props
@@ -1,7 +1,6 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <VersionPrefix>12.0.0</VersionPrefix>
-    <VersionSuffix>rc1</VersionSuffix>
     <Authors>Wiesław Šoltés</Authors>
     <Company>Wiesław Šoltés</Company>
     <Copyright>Copyright © Wiesław Šoltés 2025</Copyright>

--- a/build/XUnit.props
+++ b/build/XUnit.props
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Avalonia.Headless.XUnit" Version="12.0.0-rc1" />
-    <PackageReference Include="Avalonia.Skia" Version="12.0.0-rc1" />
+    <PackageReference Include="Avalonia.Headless.XUnit" Version="12.0.0" />
+    <PackageReference Include="Avalonia.Skia" Version="12.0.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="xunit.v3" Version="3.2.1" />

--- a/build/XUnit.props
+++ b/build/XUnit.props
@@ -1,18 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Avalonia.Headless.XUnit" Version="11.3.9" />
-    <PackageReference Include="Avalonia.Skia" Version="11.3.9" />
+    <PackageReference Include="Avalonia.Headless.XUnit" Version="12.0.0-rc1" />
+    <PackageReference Include="Avalonia.Skia" Version="12.0.0-rc1" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.abstractions" Version="2.0.3" />
-    <PackageReference Include="xunit.assert" Version="2.4.1" />
-    <PackageReference Include="xunit.core" Version="2.4.1" />
-    <PackageReference Include="xunit.extensibility.core" Version="2.4.1" />
-    <PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.console" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="xunit.v3" Version="3.2.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
   </ItemGroup>
 </Project>

--- a/samples/AvaloniaDemo.Base/AvaloniaDemo.Base.csproj
+++ b/samples/AvaloniaDemo.Base/AvaloniaDemo.Base.csproj
@@ -23,6 +23,7 @@
   <Import Project="..\..\build\Base.props" />
   <Import Project="..\..\build\ReferenceAssemblies.props" />
   <Import Project="..\..\build\Avalonia.props" />
+  <Import Project="..\..\build\Avalonia.Diagnostics.props" />
   <Import Project="..\..\build\Avalonia.Themes.Fluent.props" />
 
   <ItemGroup>

--- a/samples/AvaloniaDemo.Base/AvaloniaDemo.Base.csproj
+++ b/samples/AvaloniaDemo.Base/AvaloniaDemo.Base.csproj
@@ -17,12 +17,12 @@
     <PublishTrimmed>False</PublishTrimmed>
     <PublishSingleFile>False</PublishSingleFile>
     <PublishReadyToRun>False</PublishReadyToRun>
+    <AvaloniaUseCompiledBindingsByDefault>false</AvaloniaUseCompiledBindingsByDefault>
   </PropertyGroup>
 
   <Import Project="..\..\build\Base.props" />
   <Import Project="..\..\build\ReferenceAssemblies.props" />
   <Import Project="..\..\build\Avalonia.props" />
-  <Import Project="..\..\build\Avalonia.Diagnostics.props" />
   <Import Project="..\..\build\Avalonia.Themes.Fluent.props" />
 
   <ItemGroup>

--- a/samples/AvaloniaDemo.Base/MainWindow.axaml.cs
+++ b/samples/AvaloniaDemo.Base/MainWindow.axaml.cs
@@ -9,8 +9,5 @@ public partial class MainWindow : Window
     public MainWindow()
     {
         this.InitializeComponent();
-#if DEBUG
-        this.AttachDevTools();
-#endif
     }
 }

--- a/samples/AvaloniaDemo.Base/Views/CenterControlsView.axaml
+++ b/samples/AvaloniaDemo.Base/Views/CenterControlsView.axaml
@@ -19,7 +19,7 @@
       <Separator Margin="0,8" />
 
       <TextBlock Text="Center on Point with Zoom:" FontWeight="SemiBold" />
-      <TextBox x:Name="CenterZoomBox" Text="2.0" Watermark="Zoom level..." />
+      <TextBox x:Name="CenterZoomBox" Text="2.0" PlaceholderText="Zoom level..." />
       <Button Content="Center Point 1 @ Zoom" Click="CenterPointZoom_Click" />
 
       <Separator Margin="0,8" />

--- a/samples/AvaloniaDemo.Base/Views/SavedViewsView.axaml
+++ b/samples/AvaloniaDemo.Base/Views/SavedViewsView.axaml
@@ -15,10 +15,10 @@
 
       <TextBlock Text="Save New View:" FontWeight="SemiBold" />
       <TextBlock Text="Name:" FontSize="11" />
-      <TextBox Text="{Binding ViewName}" Watermark="Enter view name..." />
+      <TextBox Text="{Binding ViewName}" PlaceholderText="Enter view name..." />
 
       <TextBlock Text="Description:" FontSize="11" />
-      <TextBox Text="{Binding ViewDescription}" Watermark="Optional description..." />
+      <TextBox Text="{Binding ViewDescription}" PlaceholderText="Optional description..." />
 
       <Button Content="Save Current View" Click="SaveView_Click" />
 

--- a/samples/AvaloniaDemo.Desktop/AvaloniaDemo.Desktop.csproj
+++ b/samples/AvaloniaDemo.Desktop/AvaloniaDemo.Desktop.csproj
@@ -23,7 +23,6 @@
   <Import Project="..\..\build\ReferenceAssemblies.props" />
   <Import Project="..\..\build\Avalonia.props" />
   <Import Project="..\..\build\Avalonia.Desktop.props" />
-  <Import Project="..\..\build\Avalonia.Diagnostics.props" />
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\PanAndZoom\PanAndZoom.csproj" />

--- a/samples/AvaloniaDemo.Desktop/AvaloniaDemo.Desktop.csproj
+++ b/samples/AvaloniaDemo.Desktop/AvaloniaDemo.Desktop.csproj
@@ -23,6 +23,7 @@
   <Import Project="..\..\build\ReferenceAssemblies.props" />
   <Import Project="..\..\build\Avalonia.props" />
   <Import Project="..\..\build\Avalonia.Desktop.props" />
+  <Import Project="..\..\build\Avalonia.Diagnostics.props" />
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\PanAndZoom\PanAndZoom.csproj" />

--- a/site/articles/getting-started/installation.md
+++ b/site/articles/getting-started/installation.md
@@ -46,8 +46,8 @@ For xUnit headless tests, you also need the standard Avalonia headless test pack
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Avalonia.Headless.XUnit" Version="11.3.9" />
-  <PackageReference Include="Avalonia.Skia" Version="11.3.9" />
+  <PackageReference Include="Avalonia.Headless.XUnit" Version="12.0.0-rc1" />
+  <PackageReference Include="Avalonia.Skia" Version="12.0.0-rc1" />
 </ItemGroup>
 ```
 

--- a/site/articles/getting-started/installation.md
+++ b/site/articles/getting-started/installation.md
@@ -46,8 +46,8 @@ For xUnit headless tests, you also need the standard Avalonia headless test pack
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Avalonia.Headless.XUnit" Version="12.0.0-rc1" />
-  <PackageReference Include="Avalonia.Skia" Version="12.0.0-rc1" />
+  <PackageReference Include="Avalonia.Headless.XUnit" Version="12.0.0" />
+  <PackageReference Include="Avalonia.Skia" Version="12.0.0" />
 </ItemGroup>
 ```
 

--- a/src/HeadlessTestingFramework/Appium/AvaloniaElement.cs
+++ b/src/HeadlessTestingFramework/Appium/AvaloniaElement.cs
@@ -100,7 +100,8 @@ public class AvaloniaElement
         get
         {
             var bounds = _control.Bounds;
-            if (TopLevel.GetTopLevel(_control) is Visual root)
+            var root = _control.GetPresentationSource()?.RootVisual as Visual;
+            if (root != null)
             {
                 var transform = _control.TransformToVisual(root);
                 if (transform.HasValue)

--- a/src/HeadlessTestingFramework/Appium/AvaloniaElement.cs
+++ b/src/HeadlessTestingFramework/Appium/AvaloniaElement.cs
@@ -100,7 +100,7 @@ public class AvaloniaElement
         get
         {
             var bounds = _control.Bounds;
-            if (_control.GetVisualRoot() is Visual root)
+            if (TopLevel.GetTopLevel(_control) is Visual root)
             {
                 var transform = _control.TransformToVisual(root);
                 if (transform.HasValue)

--- a/src/HeadlessTestingFramework/Appium/ExpectedConditions.cs
+++ b/src/HeadlessTestingFramework/Appium/ExpectedConditions.cs
@@ -596,7 +596,7 @@ public static class ExpectedConditions
             {
                 // Check if element is still attached
                 _ = element.Control.Parent;
-                return TopLevel.GetTopLevel(element.Control) == null;
+                return element.Control.GetPresentationSource() == null;
             }
             catch
             {

--- a/src/HeadlessTestingFramework/Appium/ExpectedConditions.cs
+++ b/src/HeadlessTestingFramework/Appium/ExpectedConditions.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Avalonia.Controls;
 using Avalonia.VisualTree;
 
 namespace Avalonia.HeadlessTestingFramework.Appium;
@@ -595,7 +596,7 @@ public static class ExpectedConditions
             {
                 // Check if element is still attached
                 _ = element.Control.Parent;
-                return element.Control.GetVisualRoot() == null;
+                return TopLevel.GetTopLevel(element.Control) == null;
             }
             catch
             {

--- a/src/HeadlessTestingFramework/GestureRecognizerTestHelper.cs
+++ b/src/HeadlessTestingFramework/GestureRecognizerTestHelper.cs
@@ -171,7 +171,7 @@ public class GestureRecognizerTestHelper
         {
             // When gesture recognizer has captured, the source should be the recognizer's Target
             var recognizerTarget = (s_gestureRecognizerTargetProperty?.GetValue(capturedRecognizer) as Interactive) ?? source;
-            var root = Avalonia.Controls.TopLevel.GetTopLevel((Visual)target) ?? (Visual)target;
+            var root = ((Visual)target).GetPresentationSource()?.RootVisual as Visual ?? (Visual)target;
             
             // Transform position from target coordinates to root coordinates
             // The PointerEventArgs expects position in root visual coordinate space

--- a/src/HeadlessTestingFramework/GestureRecognizerTestHelper.cs
+++ b/src/HeadlessTestingFramework/GestureRecognizerTestHelper.cs
@@ -26,14 +26,14 @@ namespace Avalonia.HeadlessTestingFramework;
 /// <code>
 /// // CORRECT pattern:
 /// var control = new MyControl();
-/// Gestures.AddPinchHandler(control, handler);  // Register FIRST
+/// control.AddHandler(InputElement.PinchEvent, handler);  // Register FIRST
 /// var window = new Window { Content = control };
 /// window.Show();  // Show AFTER
 /// 
 /// // WRONG pattern (events won't fire):
 /// var window = new Window { Content = control };
 /// window.Show();  // Show FIRST
-/// Gestures.AddPinchHandler(control, handler);  // Too late!
+/// control.AddHandler(InputElement.PinchEvent, handler);  // Too late!
 /// </code>
 /// </example>
 /// </remarks>
@@ -171,7 +171,7 @@ public class GestureRecognizerTestHelper
         {
             // When gesture recognizer has captured, the source should be the recognizer's Target
             var recognizerTarget = (s_gestureRecognizerTargetProperty?.GetValue(capturedRecognizer) as Interactive) ?? source;
-            var root = (target as Visual)?.GetVisualRoot() as Visual ?? (Visual)target;
+            var root = Avalonia.Controls.TopLevel.GetTopLevel((Visual)target) ?? (Visual)target;
             
             // Transform position from target coordinates to root coordinates
             // The PointerEventArgs expects position in root visual coordinate space

--- a/src/HeadlessTestingFramework/GestureSimulator.cs
+++ b/src/HeadlessTestingFramework/GestureSimulator.cs
@@ -25,6 +25,13 @@ namespace Avalonia.HeadlessTestingFramework;
 /// </remarks>
 public class GestureSimulator
 {
+    private static readonly ConstructorInfo? s_holdingRoutedEventArgsCtor =
+        typeof(HoldingRoutedEventArgs).GetConstructor(
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+            binder: null,
+            types: [typeof(HoldingState), typeof(Point), typeof(PointerType), typeof(PointerEventArgs)],
+            modifiers: null);
+
     private ulong _timestamp;
     private int _nextGestureId;
     private int _nextPointerId;
@@ -98,7 +105,7 @@ public class GestureSimulator
             MouseButton.Left);
         
         // Create TappedEventArgs with the proper constructor
-        var args = new TappedEventArgs(Gestures.TappedEvent, pointerEventArgs);
+        var args = new TappedEventArgs(InputElement.TappedEvent, pointerEventArgs);
         args.Source = target;
         
         target.RaiseEvent(args);
@@ -126,7 +133,7 @@ public class GestureSimulator
             modifiers,
             MouseButton.Left);
         
-        var args = new TappedEventArgs(Gestures.DoubleTappedEvent, pointerEventArgs);
+        var args = new TappedEventArgs(InputElement.DoubleTappedEvent, pointerEventArgs);
         args.Source = target;
         
         target.RaiseEvent(args);
@@ -154,7 +161,7 @@ public class GestureSimulator
             modifiers,
             MouseButton.Right);
         
-        var args = new TappedEventArgs(Gestures.RightTappedEvent, pointerEventArgs);
+        var args = new TappedEventArgs(InputElement.RightTappedEvent, pointerEventArgs);
         args.Source = target;
         
         target.RaiseEvent(args);
@@ -172,11 +179,9 @@ public class GestureSimulator
     /// <param name="pointerType">Type of pointer (Touch, Mouse, Pen).</param>
     public void HoldingStarted(Interactive target, Point position, PointerType pointerType = PointerType.Touch)
     {
-        var args = new HoldingRoutedEventArgs(HoldingState.Started, position, pointerType)
-        {
-            RoutedEvent = Gestures.HoldingEvent,
-            Source = target
-        };
+        var args = CreateHoldingRoutedEventArgs(HoldingState.Started, target, position, pointerType);
+        args.RoutedEvent = InputElement.HoldingEvent;
+        args.Source = target;
         
         target.RaiseEvent(args);
     }
@@ -189,11 +194,9 @@ public class GestureSimulator
     /// <param name="pointerType">Type of pointer (Touch, Mouse, Pen).</param>
     public void HoldingCompleted(Interactive target, Point position, PointerType pointerType = PointerType.Touch)
     {
-        var args = new HoldingRoutedEventArgs(HoldingState.Completed, position, pointerType)
-        {
-            RoutedEvent = Gestures.HoldingEvent,
-            Source = target
-        };
+        var args = CreateHoldingRoutedEventArgs(HoldingState.Completed, target, position, pointerType);
+        args.RoutedEvent = InputElement.HoldingEvent;
+        args.Source = target;
         
         target.RaiseEvent(args);
     }
@@ -206,11 +209,9 @@ public class GestureSimulator
     /// <param name="pointerType">Type of pointer (Touch, Mouse, Pen).</param>
     public void HoldingCancelled(Interactive target, Point position, PointerType pointerType = PointerType.Touch)
     {
-        var args = new HoldingRoutedEventArgs(HoldingState.Cancelled, position, pointerType)
-        {
-            RoutedEvent = Gestures.HoldingEvent,
-            Source = target
-        };
+        var args = CreateHoldingRoutedEventArgs(HoldingState.Canceled, target, position, pointerType);
+        args.RoutedEvent = InputElement.HoldingEvent;
+        args.Source = target;
         
         target.RaiseEvent(args);
     }
@@ -245,7 +246,7 @@ public class GestureSimulator
     {
         var args = new PinchEventArgs(scale, scaleOrigin, angleDelta, distance)
         {
-            RoutedEvent = Gestures.PinchEvent,
+            RoutedEvent = InputElement.PinchEvent,
             Source = target
         };
 
@@ -260,7 +261,7 @@ public class GestureSimulator
     {
         var args = new PinchEndedEventArgs()
         {
-            RoutedEvent = Gestures.PinchEndedEvent,
+            RoutedEvent = InputElement.PinchEndedEvent,
             Source = target
         };
 
@@ -336,7 +337,7 @@ public class GestureSimulator
         var id = gestureId ?? GetNextGestureId();
         var args = new ScrollGestureEventArgs(id, delta)
         {
-            RoutedEvent = Gestures.ScrollGestureEvent,
+            RoutedEvent = InputElement.ScrollGestureEvent,
             Source = target
         };
 
@@ -352,7 +353,7 @@ public class GestureSimulator
     {
         var args = new ScrollGestureEndedEventArgs(gestureId)
         {
-            RoutedEvent = Gestures.ScrollGestureEndedEvent,
+            RoutedEvent = InputElement.ScrollGestureEndedEvent,
             Source = target
         };
 
@@ -386,7 +387,7 @@ public class GestureSimulator
             if (constructor == null) return false;
             
             var args = (RoutedEventArgs)constructor.Invoke(new object[] { gestureId, inertia });
-            args.RoutedEvent = Gestures.ScrollGestureInertiaStartingEvent;
+            args.RoutedEvent = InputElement.ScrollGestureInertiaStartingEvent;
             args.Source = target;
             
             target.RaiseEvent(args);
@@ -450,7 +451,7 @@ public class GestureSimulator
         var id = gestureId ?? GetNextGestureId();
         var args = new PullGestureEventArgs(id, delta, direction)
         {
-            RoutedEvent = Gestures.PullGestureEvent,
+            RoutedEvent = InputElement.PullGestureEvent,
             Source = target
         };
 
@@ -467,7 +468,7 @@ public class GestureSimulator
     {
         var args = new PullGestureEndedEventArgs(gestureId, direction)
         {
-            RoutedEvent = Gestures.PullGestureEndedEvent,
+            RoutedEvent = InputElement.PullGestureEndedEvent,
             Source = target
         };
 
@@ -522,7 +523,7 @@ public class GestureSimulator
     /// <param name="modifiers">Key modifiers.</param>
     public void TouchpadMagnify(Interactive target, Vector delta, Point position, KeyModifiers modifiers = KeyModifiers.None)
     {
-        var args = CreatePointerDeltaEventArgs(target, delta, position, Gestures.PointerTouchPadGestureMagnifyEvent, modifiers);
+        var args = CreatePointerDeltaEventArgs(target, delta, position, InputElement.PointerTouchPadGestureMagnifyEvent, modifiers);
         target.RaiseEvent(args);
     }
 
@@ -535,7 +536,7 @@ public class GestureSimulator
     /// <param name="modifiers">Key modifiers.</param>
     public void TouchpadRotate(Interactive target, double angleDelta, Point position, KeyModifiers modifiers = KeyModifiers.None)
     {
-        var args = CreatePointerDeltaEventArgs(target, new Vector(angleDelta, 0), position, Gestures.PointerTouchPadGestureRotateEvent, modifiers);
+        var args = CreatePointerDeltaEventArgs(target, new Vector(angleDelta, 0), position, InputElement.PointerTouchPadGestureRotateEvent, modifiers);
         target.RaiseEvent(args);
     }
 
@@ -548,7 +549,7 @@ public class GestureSimulator
     /// <param name="modifiers">Key modifiers.</param>
     public void TouchpadSwipe(Interactive target, Vector delta, Point position, KeyModifiers modifiers = KeyModifiers.None)
     {
-        var args = CreatePointerDeltaEventArgs(target, delta, position, Gestures.PointerTouchPadGestureSwipeEvent, modifiers);
+        var args = CreatePointerDeltaEventArgs(target, delta, position, InputElement.PointerTouchPadGestureSwipeEvent, modifiers);
         target.RaiseEvent(args);
     }
 
@@ -720,6 +721,37 @@ public class GestureSimulator
     private Avalonia.Input.Pointer CreatePointer(PointerType pointerType)
     {
         return new Avalonia.Input.Pointer(_nextPointerId++, pointerType, true);
+    }
+
+    private HoldingRoutedEventArgs CreateHoldingRoutedEventArgs(
+        HoldingState holdingState,
+        Interactive target,
+        Point position,
+        PointerType pointerType)
+    {
+        if (s_holdingRoutedEventArgsCtor is null)
+        {
+            throw new MissingMethodException(typeof(HoldingRoutedEventArgs).FullName, ".ctor(HoldingState, Point, PointerType, PointerEventArgs)");
+        }
+
+        return (HoldingRoutedEventArgs)s_holdingRoutedEventArgsCtor.Invoke(
+            [holdingState, position, pointerType, CreatePointerEventArgs(target, position, pointerType)]);
+    }
+
+    private PointerEventArgs CreatePointerEventArgs(Interactive target, Point position, PointerType pointerType)
+    {
+        var pointer = CreatePointer(pointerType);
+        var properties = new PointerPointProperties(RawInputModifiers.None, PointerUpdateKind.Other);
+
+        return new PointerEventArgs(
+            InputElement.PointerMovedEvent,
+            target,
+            pointer,
+            (Visual)target,
+            position,
+            _timestamp,
+            properties,
+            KeyModifiers.None);
     }
 
     private PointerDeltaEventArgs CreatePointerDeltaEventArgs(Interactive target, Vector delta, Point position, RoutedEvent routedEvent, KeyModifiers modifiers)

--- a/src/HeadlessTestingFramework/GestureSimulator.cs
+++ b/src/HeadlessTestingFramework/GestureSimulator.cs
@@ -8,6 +8,7 @@ using Avalonia.Input;
 using Avalonia.Input.GestureRecognizers;
 using Avalonia.Input.Raw;
 using Avalonia.Interactivity;
+using Avalonia.VisualTree;
 
 namespace Avalonia.HeadlessTestingFramework;
 
@@ -179,11 +180,7 @@ public class GestureSimulator
     /// <param name="pointerType">Type of pointer (Touch, Mouse, Pen).</param>
     public void HoldingStarted(Interactive target, Point position, PointerType pointerType = PointerType.Touch)
     {
-        var args = CreateHoldingRoutedEventArgs(HoldingState.Started, target, position, pointerType);
-        args.RoutedEvent = InputElement.HoldingEvent;
-        args.Source = target;
-        
-        target.RaiseEvent(args);
+        RaiseHolding(target, HoldingState.Started, position, pointerType);
     }
 
     /// <summary>
@@ -194,11 +191,7 @@ public class GestureSimulator
     /// <param name="pointerType">Type of pointer (Touch, Mouse, Pen).</param>
     public void HoldingCompleted(Interactive target, Point position, PointerType pointerType = PointerType.Touch)
     {
-        var args = CreateHoldingRoutedEventArgs(HoldingState.Completed, target, position, pointerType);
-        args.RoutedEvent = InputElement.HoldingEvent;
-        args.Source = target;
-        
-        target.RaiseEvent(args);
+        RaiseHolding(target, HoldingState.Completed, position, pointerType);
     }
 
     /// <summary>
@@ -209,11 +202,7 @@ public class GestureSimulator
     /// <param name="pointerType">Type of pointer (Touch, Mouse, Pen).</param>
     public void HoldingCancelled(Interactive target, Point position, PointerType pointerType = PointerType.Touch)
     {
-        var args = CreateHoldingRoutedEventArgs(HoldingState.Canceled, target, position, pointerType);
-        args.RoutedEvent = InputElement.HoldingEvent;
-        args.Source = target;
-        
-        target.RaiseEvent(args);
+        RaiseHolding(target, HoldingState.Canceled, position, pointerType);
     }
 
     /// <summary>
@@ -225,9 +214,10 @@ public class GestureSimulator
     /// <param name="pointerType">Type of pointer (Touch, Mouse, Pen).</param>
     public void Hold(Interactive target, Point position, int holdDuration = 500, PointerType pointerType = PointerType.Touch)
     {
-        HoldingStarted(target, position, pointerType);
+        var pointer = CreatePointer(pointerType);
+        RaiseHolding(target, HoldingState.Started, position, pointerType, pointer);
         AdvanceTime(holdDuration);
-        HoldingCompleted(target, position, pointerType);
+        RaiseHolding(target, HoldingState.Completed, position, pointerType, pointer);
     }
 
     #endregion
@@ -723,11 +713,31 @@ public class GestureSimulator
         return new Avalonia.Input.Pointer(_nextPointerId++, pointerType, true);
     }
 
+    private void RaiseHolding(
+        Interactive target,
+        HoldingState holdingState,
+        Point position,
+        PointerType pointerType,
+        Avalonia.Input.Pointer? pointer = null)
+    {
+        var args = CreateHoldingRoutedEventArgs(
+            holdingState,
+            target,
+            position,
+            pointerType,
+            pointer ?? CreatePointer(pointerType));
+        args.RoutedEvent = InputElement.HoldingEvent;
+        args.Source = target;
+
+        target.RaiseEvent(args);
+    }
+
     private HoldingRoutedEventArgs CreateHoldingRoutedEventArgs(
         HoldingState holdingState,
         Interactive target,
         Point position,
-        PointerType pointerType)
+        PointerType pointerType,
+        Avalonia.Input.Pointer pointer)
     {
         if (s_holdingRoutedEventArgsCtor is null)
         {
@@ -735,17 +745,27 @@ public class GestureSimulator
         }
 
         return (HoldingRoutedEventArgs)s_holdingRoutedEventArgsCtor.Invoke(
-            [holdingState, position, pointerType, CreateHoldingPointerEventArgs(holdingState, target, position, pointerType)]);
+            [holdingState, position, pointerType, CreateHoldingPointerEventArgs(holdingState, target, position, pointer)]);
     }
 
     private PointerEventArgs CreateHoldingPointerEventArgs(
         HoldingState holdingState,
         Interactive target,
         Point position,
-        PointerType pointerType)
+        Avalonia.Input.Pointer pointer)
     {
-        var pointer = CreatePointer(pointerType);
-        var root = (Visual)target;
+        var targetVisual = (Visual)target;
+        var root = ResolvePresentationRoot(target);
+        var rootPosition = position;
+
+        if (root != targetVisual)
+        {
+            var transform = targetVisual.TransformToVisual(root);
+            if (transform.HasValue)
+            {
+                rootPosition = transform.Value.Transform(position);
+            }
+        }
 
         return holdingState switch
         {
@@ -753,7 +773,7 @@ public class GestureSimulator
                 target,
                 pointer,
                 root,
-                position,
+                rootPosition,
                 _timestamp,
                 new PointerPointProperties(RawInputModifiers.None, PointerUpdateKind.LeftButtonPressed),
                 KeyModifiers.None,
@@ -762,7 +782,7 @@ public class GestureSimulator
                 target,
                 pointer,
                 root,
-                position,
+                rootPosition,
                 _timestamp,
                 new PointerPointProperties(RawInputModifiers.None, PointerUpdateKind.LeftButtonReleased),
                 KeyModifiers.None,
@@ -772,11 +792,17 @@ public class GestureSimulator
                 target,
                 pointer,
                 root,
-                position,
+                rootPosition,
                 _timestamp,
                 new PointerPointProperties(RawInputModifiers.None, PointerUpdateKind.Other),
                 KeyModifiers.None)
         };
+    }
+
+    private static Visual ResolvePresentationRoot(Interactive target)
+    {
+        var targetVisual = (Visual)target;
+        return targetVisual.GetPresentationSource()?.RootVisual as Visual ?? targetVisual;
     }
 
     private PointerDeltaEventArgs CreatePointerDeltaEventArgs(Interactive target, Vector delta, Point position, RoutedEvent routedEvent, KeyModifiers modifiers)

--- a/src/HeadlessTestingFramework/GestureSimulator.cs
+++ b/src/HeadlessTestingFramework/GestureSimulator.cs
@@ -735,23 +735,48 @@ public class GestureSimulator
         }
 
         return (HoldingRoutedEventArgs)s_holdingRoutedEventArgsCtor.Invoke(
-            [holdingState, position, pointerType, CreatePointerEventArgs(target, position, pointerType)]);
+            [holdingState, position, pointerType, CreateHoldingPointerEventArgs(holdingState, target, position, pointerType)]);
     }
 
-    private PointerEventArgs CreatePointerEventArgs(Interactive target, Point position, PointerType pointerType)
+    private PointerEventArgs CreateHoldingPointerEventArgs(
+        HoldingState holdingState,
+        Interactive target,
+        Point position,
+        PointerType pointerType)
     {
         var pointer = CreatePointer(pointerType);
-        var properties = new PointerPointProperties(RawInputModifiers.None, PointerUpdateKind.Other);
+        var root = (Visual)target;
 
-        return new PointerEventArgs(
-            InputElement.PointerMovedEvent,
-            target,
-            pointer,
-            (Visual)target,
-            position,
-            _timestamp,
-            properties,
-            KeyModifiers.None);
+        return holdingState switch
+        {
+            HoldingState.Started => new PointerPressedEventArgs(
+                target,
+                pointer,
+                root,
+                position,
+                _timestamp,
+                new PointerPointProperties(RawInputModifiers.None, PointerUpdateKind.LeftButtonPressed),
+                KeyModifiers.None,
+                clickCount: 1),
+            HoldingState.Completed => new PointerReleasedEventArgs(
+                target,
+                pointer,
+                root,
+                position,
+                _timestamp,
+                new PointerPointProperties(RawInputModifiers.None, PointerUpdateKind.LeftButtonReleased),
+                KeyModifiers.None,
+                MouseButton.Left),
+            _ => new PointerEventArgs(
+                InputElement.PointerMovedEvent,
+                target,
+                pointer,
+                root,
+                position,
+                _timestamp,
+                new PointerPointProperties(RawInputModifiers.None, PointerUpdateKind.Other),
+                KeyModifiers.None)
+        };
     }
 
     private PointerDeltaEventArgs CreatePointerDeltaEventArgs(Interactive target, Vector delta, Point position, RoutedEvent routedEvent, KeyModifiers modifiers)

--- a/src/HeadlessTestingFramework/HeadlessTestingFramework.csproj
+++ b/src/HeadlessTestingFramework/HeadlessTestingFramework.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <OutputType>Library</OutputType>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <Nullable>enable</Nullable>

--- a/src/HeadlessTestingFramework/TouchInputSimulator.cs
+++ b/src/HeadlessTestingFramework/TouchInputSimulator.cs
@@ -190,7 +190,7 @@ public class TouchInputSimulator
     {
         var args = new PinchEventArgs(scale, scaleOrigin, angleDelta, distance)
         {
-            RoutedEvent = Gestures.PinchEvent,
+            RoutedEvent = InputElement.PinchEvent,
             Source = target
         };
 
@@ -205,7 +205,7 @@ public class TouchInputSimulator
     {
         var args = new PinchEndedEventArgs()
         {
-            RoutedEvent = Gestures.PinchEndedEvent,
+            RoutedEvent = InputElement.PinchEndedEvent,
             Source = target
         };
 
@@ -222,7 +222,7 @@ public class TouchInputSimulator
     {
         var args = new ScrollGestureEventArgs(gestureId, delta)
         {
-            RoutedEvent = Gestures.ScrollGestureEvent,
+            RoutedEvent = InputElement.ScrollGestureEvent,
             Source = target
         };
 
@@ -238,7 +238,7 @@ public class TouchInputSimulator
     {
         var args = new ScrollGestureEndedEventArgs(gestureId)
         {
-            RoutedEvent = Gestures.ScrollGestureEndedEvent,
+            RoutedEvent = InputElement.ScrollGestureEndedEvent,
             Source = target
         };
 
@@ -254,7 +254,7 @@ public class TouchInputSimulator
     /// <param name="modifiers">Key modifiers.</param>
     public void TouchpadMagnify(Interactive target, Vector delta, Point position, KeyModifiers modifiers = KeyModifiers.None)
     {
-        var args = CreatePointerDeltaEventArgs(target, delta, position, Gestures.PointerTouchPadGestureMagnifyEvent, modifiers);
+        var args = CreatePointerDeltaEventArgs(target, delta, position, InputElement.PointerTouchPadGestureMagnifyEvent, modifiers);
         target.RaiseEvent(args);
     }
 
@@ -267,7 +267,7 @@ public class TouchInputSimulator
     /// <param name="modifiers">Key modifiers.</param>
     public void TouchpadSwipe(Interactive target, Vector delta, Point position, KeyModifiers modifiers = KeyModifiers.None)
     {
-        var args = CreatePointerDeltaEventArgs(target, delta, position, Gestures.PointerTouchPadGestureSwipeEvent, modifiers);
+        var args = CreatePointerDeltaEventArgs(target, delta, position, InputElement.PointerTouchPadGestureSwipeEvent, modifiers);
         target.RaiseEvent(args);
     }
 
@@ -280,7 +280,7 @@ public class TouchInputSimulator
     /// <param name="modifiers">Key modifiers.</param>
     public void TouchpadRotate(Interactive target, double delta, Point position, KeyModifiers modifiers = KeyModifiers.None)
     {
-        var args = CreatePointerDeltaEventArgs(target, new Vector(delta, 0), position, Gestures.PointerTouchPadGestureRotateEvent, modifiers);
+        var args = CreatePointerDeltaEventArgs(target, new Vector(delta, 0), position, InputElement.PointerTouchPadGestureRotateEvent, modifiers);
         target.RaiseEvent(args);
     }
 

--- a/src/PanAndZoom/PanAndZoom.csproj
+++ b/src/PanAndZoom/PanAndZoom.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <OutputType>Library</OutputType>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <Nullable>enable</Nullable>

--- a/src/PanAndZoom/ZoomBorder.ILogicalScrollable.cs
+++ b/src/PanAndZoom/ZoomBorder.ILogicalScrollable.cs
@@ -135,7 +135,10 @@ public partial class ZoomBorder : ILogicalScrollable
     /// <inheritdoc/>
     Size IScrollable.Viewport => _viewport;
 
-    bool ILogicalScrollable.CanHorizontallyScroll
+    /// <summary>
+    /// Gets or sets whether horizontal scrolling is enabled for the logical scroll contract.
+    /// </summary>
+    public bool CanHorizontallyScroll
     {
         get => _canHorizontallyScroll;
         set
@@ -145,7 +148,10 @@ public partial class ZoomBorder : ILogicalScrollable
         }
     }
 
-    bool ILogicalScrollable.CanVerticallyScroll
+    /// <summary>
+    /// Gets or sets whether vertical scrolling is enabled for the logical scroll contract.
+    /// </summary>
+    public bool CanVerticallyScroll
     {
         get => _canVerticallyScroll;
         set

--- a/src/PanAndZoom/ZoomBorder.cs
+++ b/src/PanAndZoom/ZoomBorder.cs
@@ -207,13 +207,13 @@ public partial class ZoomBorder : Border
         KeyDown += Border_KeyDown;
 
         // Add gesture event handlers
-        AddHandler(Gestures.PinchEvent, Border_PinchGesture);
-        AddHandler(Gestures.PinchEndedEvent, Border_PinchGestureEnded);
-        AddHandler(Gestures.ScrollGestureEvent, Border_ScrollGesture);
-        AddHandler(Gestures.ScrollGestureEndedEvent, Border_ScrollGestureEnded);
+        AddHandler(InputElement.PinchEvent, Border_PinchGesture);
+        AddHandler(InputElement.PinchEndedEvent, Border_PinchGestureEnded);
+        AddHandler(InputElement.ScrollGestureEvent, Border_ScrollGesture);
+        AddHandler(InputElement.ScrollGestureEndedEvent, Border_ScrollGestureEnded);
         
         // Add touch pad gesture handler
-        Gestures.AddPointerTouchPadGestureMagnifyHandler(this, Border_Magnified);
+        AddHandler(InputElement.PointerTouchPadGestureMagnifyEvent, Border_Magnified);
 
         // Update gesture recognizers based on the new state
         UpdateGestureRecognizers();
@@ -241,13 +241,13 @@ public partial class ZoomBorder : Border
         KeyDown -= Border_KeyDown;
 
         // Remove gesture event handlers
-        RemoveHandler(Gestures.PinchEvent, Border_PinchGesture);
-        RemoveHandler(Gestures.PinchEndedEvent, Border_PinchGestureEnded);
-        RemoveHandler(Gestures.ScrollGestureEvent, Border_ScrollGesture);
-        RemoveHandler(Gestures.ScrollGestureEndedEvent, Border_ScrollGestureEnded);
+        RemoveHandler(InputElement.PinchEvent, Border_PinchGesture);
+        RemoveHandler(InputElement.PinchEndedEvent, Border_PinchGestureEnded);
+        RemoveHandler(InputElement.ScrollGestureEvent, Border_ScrollGesture);
+        RemoveHandler(InputElement.ScrollGestureEndedEvent, Border_ScrollGestureEnded);
         
         // Remove touch pad gesture handler
-        Gestures.RemovePointerTouchPadGestureMagnifyHandler(this, Border_Magnified);
+        RemoveHandler(InputElement.PointerTouchPadGestureMagnifyEvent, Border_Magnified);
     }
 
     private void Border_Magnified(object? sender, PointerDeltaEventArgs e)

--- a/tests/Avalonia.Controls.PanAndZoom.UnitTests/AppiumApiTests.cs
+++ b/tests/Avalonia.Controls.PanAndZoom.UnitTests/AppiumApiTests.cs
@@ -817,6 +817,56 @@ public class AppiumApiTests
         Assert.True(result);
     }
 
+    [AvaloniaFact]
+    public void ExpectedConditions_StalenessOf_ReturnsFalse_WhenElementIsAttached()
+    {
+        var panel = new StackPanel { Name = "RootPanel" };
+        var button = new Button { Name = "TrackedButton", Content = "Tracked" };
+        panel.Children.Add(button);
+
+        var window = new Window
+        {
+            Title = "Attached Root",
+            Width = 300,
+            Height = 200,
+            Content = panel
+        };
+        window.Show();
+
+        using var driver = new AvaloniaDriver(panel);
+
+        var element = driver.FindElement(By.Id("TrackedButton"));
+        var isStale = ExpectedConditions.StalenessOf(element)(driver);
+
+        Assert.False(isStale);
+    }
+
+    [AvaloniaFact]
+    public void ExpectedConditions_StalenessOf_ReturnsTrue_WhenElementIsDetached()
+    {
+        var panel = new StackPanel { Name = "RootPanel" };
+        var button = new Button { Name = "TrackedButton", Content = "Tracked" };
+        panel.Children.Add(button);
+
+        var window = new Window
+        {
+            Title = "Detached Root",
+            Width = 300,
+            Height = 200,
+            Content = panel
+        };
+        window.Show();
+
+        using var driver = new AvaloniaDriver(panel);
+
+        var element = driver.FindElement(By.Id("TrackedButton"));
+        panel.Children.Remove(button);
+
+        var isStale = ExpectedConditions.StalenessOf(element)(driver);
+
+        Assert.True(isStale);
+    }
+
     #endregion
 
     #region Window Management Tests

--- a/tests/Avalonia.Controls.PanAndZoom.UnitTests/AppiumApiTests.cs
+++ b/tests/Avalonia.Controls.PanAndZoom.UnitTests/AppiumApiTests.cs
@@ -593,7 +593,7 @@ public class AppiumApiTests
 
         var action = driver.CreateTouchAction()
             .Press(100, 100)
-            .Swipe(SwipeDirection.Up, 200)
+            .Swipe(Avalonia.HeadlessTestingFramework.SwipeDirection.Up, 200)
             .Release();
 
         Assert.NotNull(action);

--- a/tests/Avalonia.Controls.PanAndZoom.UnitTests/ControlFinderTests.cs
+++ b/tests/Avalonia.Controls.PanAndZoom.UnitTests/ControlFinderTests.cs
@@ -53,8 +53,8 @@ public class ControlFinderTests
         var text1 = new TextBlock { Name = "LabelText", Text = "Hello World" };
         var text2 = new TextBlock { Name = "DescText", Text = "Description goes here" };
         
-        var input1 = new TextBox { Name = "NameInput", Text = "John Doe", Watermark = "Enter name" };
-        var input2 = new TextBox { Name = "EmailInput", Text = "", Watermark = "Enter email" };
+        var input1 = new TextBox { Name = "NameInput", Text = "John Doe", PlaceholderText = "Enter name" };
+        var input2 = new TextBox { Name = "EmailInput", Text = "", PlaceholderText = "Enter email" };
         
         // Nested structure
         var container = new Border

--- a/tests/Avalonia.Controls.PanAndZoom.UnitTests/GestureSimulatorSamples.cs
+++ b/tests/Avalonia.Controls.PanAndZoom.UnitTests/GestureSimulatorSamples.cs
@@ -65,7 +65,7 @@ public class GestureSimulatorSamples
         
         // Register handlers BEFORE showing window
         var doubleTapCount = 0;
-        zoomBorder.AddHandler(Gestures.DoubleTappedEvent, (s, e) => doubleTapCount++);
+        zoomBorder.AddHandler(InputElement.DoubleTappedEvent, (s, e) => doubleTapCount++);
 
         var window = new Window { Content = zoomBorder };
         window.Show();
@@ -94,7 +94,7 @@ public class GestureSimulatorSamples
         };
         
         var rightTapPosition = default(Point);
-        target.AddHandler(Gestures.RightTappedEvent, (s, e) =>
+        target.AddHandler(InputElement.RightTappedEvent, (s, e) =>
         {
             if (e is TappedEventArgs tapped)
             {
@@ -133,7 +133,7 @@ public class GestureSimulatorSamples
         };
 
         var scales = new List<double>();
-        zoomBorder.AddHandler(Gestures.PinchEvent, (s, e) =>
+        zoomBorder.AddHandler(InputElement.PinchEvent, (s, e) =>
         {
             if (e is PinchEventArgs pinch)
             {
@@ -173,7 +173,7 @@ public class GestureSimulatorSamples
         };
 
         var scales = new List<double>();
-        zoomBorder.AddHandler(Gestures.PinchEvent, (s, e) =>
+        zoomBorder.AddHandler(InputElement.PinchEvent, (s, e) =>
         {
             if (e is PinchEventArgs pinch)
             {
@@ -213,7 +213,7 @@ public class GestureSimulatorSamples
         };
 
         var pinchCount = 0;
-        target.AddHandler(Gestures.PinchEvent, (s, e) => pinchCount++);
+        target.AddHandler(InputElement.PinchEvent, (s, e) => pinchCount++);
 
         var window = new Window { Content = target };
         window.Show();
@@ -251,7 +251,7 @@ public class GestureSimulatorSamples
         var scrollViewer = new ScrollViewer { Content = content };
         
         var scrollDelta = Vector.Zero;
-        scrollViewer.AddHandler(Gestures.ScrollGestureEvent, (s, e) =>
+        scrollViewer.AddHandler(InputElement.ScrollGestureEvent, (s, e) =>
         {
             if (e is ScrollGestureEventArgs scroll)
             {
@@ -286,7 +286,7 @@ public class GestureSimulatorSamples
         };
 
         var scrollEventCount = 0;
-        target.AddHandler(Gestures.ScrollGestureEvent, (s, e) => scrollEventCount++);
+        target.AddHandler(InputElement.ScrollGestureEvent, (s, e) => scrollEventCount++);
 
         var window = new Window { Content = target };
         window.Show();
@@ -294,7 +294,7 @@ public class GestureSimulatorSamples
         var simulator = new GestureSimulator();
 
         // Act - Flick upward
-        simulator.Flick(target, SwipeDirection.Up, distance: 50, velocity: 500);
+        simulator.Flick(target, Avalonia.HeadlessTestingFramework.SwipeDirection.Up, distance: 50, velocity: 500);
 
         // Assert
         Assert.True(scrollEventCount > 0);
@@ -321,7 +321,7 @@ public class GestureSimulatorSamples
         var pullDistance = 0.0;
         var pullEnded = false;
 
-        refreshList.AddHandler(Gestures.PullGestureEvent, (s, e) =>
+        refreshList.AddHandler(InputElement.PullGestureEvent, (s, e) =>
         {
             if (e is PullGestureEventArgs pull)
             {
@@ -329,7 +329,7 @@ public class GestureSimulatorSamples
             }
         });
 
-        refreshList.AddHandler(Gestures.PullGestureEndedEvent, (s, e) =>
+        refreshList.AddHandler(InputElement.PullGestureEndedEvent, (s, e) =>
         {
             pullEnded = true;
             // In real app: trigger data refresh here
@@ -367,7 +367,7 @@ public class GestureSimulatorSamples
         };
 
         var magnifyDelta = 0.0;
-        target.AddHandler(Gestures.PointerTouchPadGestureMagnifyEvent, (s, e) =>
+        target.AddHandler(InputElement.PointerTouchPadGestureMagnifyEvent, (s, e) =>
         {
             if (e is PointerDeltaEventArgs delta)
             {
@@ -403,7 +403,7 @@ public class GestureSimulatorSamples
         };
 
         var swipeCount = 0;
-        navigationHost.AddHandler(Gestures.PointerTouchPadGestureSwipeEvent, (s, e) =>
+        navigationHost.AddHandler(InputElement.PointerTouchPadGestureSwipeEvent, (s, e) =>
         {
             swipeCount++;
             // In real app: navigate between pages
@@ -416,7 +416,7 @@ public class GestureSimulatorSamples
 
         // Act - Swipe left to navigate forward
         simulator.TouchpadSwipeSequence(navigationHost, new Point(200, 150), 
-            SwipeDirection.Left, distance: 100, steps: 5);
+            Avalonia.HeadlessTestingFramework.SwipeDirection.Left, distance: 100, steps: 5);
 
         // Assert
         Assert.True(swipeCount > 0);
@@ -443,8 +443,8 @@ public class GestureSimulatorSamples
         var doubleTapRaised = false;
         var pinchEvents = new List<double>();
 
-        zoomBorder.AddHandler(Gestures.DoubleTappedEvent, (s, e) => doubleTapRaised = true);
-        zoomBorder.AddHandler(Gestures.PinchEvent, (s, e) =>
+        zoomBorder.AddHandler(InputElement.DoubleTappedEvent, (s, e) => doubleTapRaised = true);
+        zoomBorder.AddHandler(InputElement.PinchEvent, (s, e) =>
         {
             if (e is PinchEventArgs pinch)
             {
@@ -480,7 +480,7 @@ public class GestureSimulatorSamples
         };
 
         var holdingStates = new List<HoldingState>();
-        target.AddHandler(Gestures.HoldingEvent, (s, e) =>
+        target.AddHandler(InputElement.HoldingEvent, (s, e) =>
         {
             if (e is HoldingRoutedEventArgs holding)
             {
@@ -529,11 +529,11 @@ public class GestureSimulatorSamples
         // Track all gesture events
         var eventsRaised = new List<string>();
         
-        control.AddHandler(Gestures.PinchEvent, (s, e) => eventsRaised.Add("Pinch"));
-        control.AddHandler(Gestures.PinchEndedEvent, (s, e) => eventsRaised.Add("PinchEnded"));
-        control.AddHandler(Gestures.ScrollGestureEvent, (s, e) => eventsRaised.Add("Scroll"));
-        control.AddHandler(Gestures.ScrollGestureEndedEvent, (s, e) => eventsRaised.Add("ScrollEnded"));
-        control.AddHandler(Gestures.DoubleTappedEvent, (s, e) => eventsRaised.Add("DoubleTap"));
+        control.AddHandler(InputElement.PinchEvent, (s, e) => eventsRaised.Add("Pinch"));
+        control.AddHandler(InputElement.PinchEndedEvent, (s, e) => eventsRaised.Add("PinchEnded"));
+        control.AddHandler(InputElement.ScrollGestureEvent, (s, e) => eventsRaised.Add("Scroll"));
+        control.AddHandler(InputElement.ScrollGestureEndedEvent, (s, e) => eventsRaised.Add("ScrollEnded"));
+        control.AddHandler(InputElement.DoubleTappedEvent, (s, e) => eventsRaised.Add("DoubleTap"));
 
         // Step 1: Zoom in with pinch gesture (typically used for zoom)
         simulator.PinchZoom(control, new Point(200, 150), 1.0, 1.5, steps: 5);

--- a/tests/Avalonia.Controls.PanAndZoom.UnitTests/GestureSimulatorTests.cs
+++ b/tests/Avalonia.Controls.PanAndZoom.UnitTests/GestureSimulatorTests.cs
@@ -157,6 +157,39 @@ public class GestureSimulatorTests
     }
 
     [AvaloniaFact]
+    public void HoldingStarted_UsesPressedPointerEventArgs()
+    {
+        var target = new Border { Width = 100, Height = 100, Background = Brushes.Red };
+        var window = new Window { Content = target };
+        window.Show();
+
+        var simulator = new GestureSimulator();
+        HoldingRoutedEventArgs? capturedHoldingArgs = null;
+
+        target.AddHandler(InputElement.HoldingEvent, (_, args) =>
+        {
+            if (args is HoldingRoutedEventArgs holding)
+            {
+                capturedHoldingArgs = holding;
+            }
+        });
+
+        simulator.HoldingStarted(target, new Point(25, 25));
+
+        Assert.NotNull(capturedHoldingArgs);
+
+        var pointerEventArgsProperty = typeof(HoldingRoutedEventArgs).GetProperty(
+            "PointerEventArgs",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic);
+        Assert.NotNull(pointerEventArgsProperty);
+
+        var capturedPointerEventArgs = pointerEventArgsProperty!.GetValue(capturedHoldingArgs) as PointerEventArgs;
+        Assert.NotNull(capturedPointerEventArgs);
+        Assert.IsType<PointerPressedEventArgs>(capturedPointerEventArgs);
+        Assert.Equal(InputElement.PointerPressedEvent, capturedPointerEventArgs!.RoutedEvent);
+    }
+
+    [AvaloniaFact]
     public void HoldingCompleted_RaisesEvent_WithCorrectState()
     {
         // Arrange
@@ -181,6 +214,39 @@ public class GestureSimulatorTests
         // Assert
         Assert.NotNull(capturedState);
         Assert.Equal(HoldingState.Completed, capturedState);
+    }
+
+    [AvaloniaFact]
+    public void HoldingCompleted_UsesReleasedPointerEventArgs()
+    {
+        var target = new Border { Width = 100, Height = 100, Background = Brushes.Red };
+        var window = new Window { Content = target };
+        window.Show();
+
+        var simulator = new GestureSimulator();
+        HoldingRoutedEventArgs? capturedHoldingArgs = null;
+
+        target.AddHandler(InputElement.HoldingEvent, (_, args) =>
+        {
+            if (args is HoldingRoutedEventArgs holding)
+            {
+                capturedHoldingArgs = holding;
+            }
+        });
+
+        simulator.HoldingCompleted(target, new Point(50, 50));
+
+        Assert.NotNull(capturedHoldingArgs);
+
+        var pointerEventArgsProperty = typeof(HoldingRoutedEventArgs).GetProperty(
+            "PointerEventArgs",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic);
+        Assert.NotNull(pointerEventArgsProperty);
+
+        var capturedPointerEventArgs = pointerEventArgsProperty!.GetValue(capturedHoldingArgs) as PointerEventArgs;
+        Assert.NotNull(capturedPointerEventArgs);
+        Assert.IsType<PointerReleasedEventArgs>(capturedPointerEventArgs);
+        Assert.Equal(InputElement.PointerReleasedEvent, capturedPointerEventArgs!.RoutedEvent);
     }
 
     [AvaloniaFact]

--- a/tests/Avalonia.Controls.PanAndZoom.UnitTests/GestureSimulatorTests.cs
+++ b/tests/Avalonia.Controls.PanAndZoom.UnitTests/GestureSimulatorTests.cs
@@ -32,7 +32,7 @@ public class GestureSimulatorTests
         var eventRaised = false;
         var eventPosition = default(Point);
 
-        target.AddHandler(Gestures.TappedEvent, (sender, args) =>
+        target.AddHandler(InputElement.TappedEvent, (sender, args) =>
         {
             eventRaised = true;
             if (args is TappedEventArgs tapped)
@@ -59,7 +59,7 @@ public class GestureSimulatorTests
         var simulator = new GestureSimulator();
         var eventRaised = false;
 
-        target.AddHandler(Gestures.DoubleTappedEvent, (sender, args) =>
+        target.AddHandler(InputElement.DoubleTappedEvent, (sender, args) =>
         {
             eventRaised = true;
         });
@@ -82,7 +82,7 @@ public class GestureSimulatorTests
         var simulator = new GestureSimulator();
         var eventRaised = false;
 
-        target.AddHandler(Gestures.RightTappedEvent, (sender, args) =>
+        target.AddHandler(InputElement.RightTappedEvent, (sender, args) =>
         {
             eventRaised = true;
         });
@@ -105,7 +105,7 @@ public class GestureSimulatorTests
         var simulator = new GestureSimulator();
         var pointerTypes = new List<PointerType>();
 
-        target.AddHandler(Gestures.TappedEvent, (sender, args) =>
+        target.AddHandler(InputElement.TappedEvent, (sender, args) =>
         {
             if (args is TappedEventArgs tapped)
             {
@@ -138,7 +138,7 @@ public class GestureSimulatorTests
         HoldingState? capturedState = null;
         Point? capturedPosition = null;
 
-        target.AddHandler(Gestures.HoldingEvent, (sender, args) =>
+        target.AddHandler(InputElement.HoldingEvent, (sender, args) =>
         {
             if (args is HoldingRoutedEventArgs holding)
             {
@@ -167,7 +167,7 @@ public class GestureSimulatorTests
         var simulator = new GestureSimulator();
         HoldingState? capturedState = null;
 
-        target.AddHandler(Gestures.HoldingEvent, (sender, args) =>
+        target.AddHandler(InputElement.HoldingEvent, (sender, args) =>
         {
             if (args is HoldingRoutedEventArgs holding)
             {
@@ -194,7 +194,7 @@ public class GestureSimulatorTests
         var simulator = new GestureSimulator();
         HoldingState? capturedState = null;
 
-        target.AddHandler(Gestures.HoldingEvent, (sender, args) =>
+        target.AddHandler(InputElement.HoldingEvent, (sender, args) =>
         {
             if (args is HoldingRoutedEventArgs holding)
             {
@@ -207,7 +207,7 @@ public class GestureSimulatorTests
 
         // Assert
         Assert.NotNull(capturedState);
-        Assert.Equal(HoldingState.Cancelled, capturedState);
+        Assert.Equal(HoldingState.Canceled, capturedState);
     }
 
     [AvaloniaFact]
@@ -221,7 +221,7 @@ public class GestureSimulatorTests
         var simulator = new GestureSimulator();
         var states = new List<HoldingState>();
 
-        target.AddHandler(Gestures.HoldingEvent, (sender, args) =>
+        target.AddHandler(InputElement.HoldingEvent, (sender, args) =>
         {
             if (args is HoldingRoutedEventArgs holding)
             {
@@ -254,7 +254,7 @@ public class GestureSimulatorTests
         double? capturedScale = null;
         Point? capturedOrigin = null;
 
-        target.AddHandler(Gestures.PinchEvent, (sender, args) =>
+        target.AddHandler(InputElement.PinchEvent, (sender, args) =>
         {
             if (args is PinchEventArgs pinch)
             {
@@ -284,7 +284,7 @@ public class GestureSimulatorTests
         var simulator = new GestureSimulator();
         var eventRaised = false;
 
-        target.AddHandler(Gestures.PinchEndedEvent, (sender, args) =>
+        target.AddHandler(InputElement.PinchEndedEvent, (sender, args) =>
         {
             eventRaised = true;
         });
@@ -309,7 +309,7 @@ public class GestureSimulatorTests
         var pinchEndedRaised = false;
         var lastScale = 0.0;
 
-        target.AddHandler(Gestures.PinchEvent, (sender, args) =>
+        target.AddHandler(InputElement.PinchEvent, (sender, args) =>
         {
             if (args is PinchEventArgs pinch)
             {
@@ -318,7 +318,7 @@ public class GestureSimulatorTests
             }
         });
 
-        target.AddHandler(Gestures.PinchEndedEvent, (sender, args) =>
+        target.AddHandler(InputElement.PinchEndedEvent, (sender, args) =>
         {
             pinchEndedRaised = true;
         });
@@ -343,7 +343,7 @@ public class GestureSimulatorTests
         var simulator = new GestureSimulator();
         var pinchCount = 0;
 
-        target.AddHandler(Gestures.PinchEvent, (sender, args) =>
+        target.AddHandler(InputElement.PinchEvent, (sender, args) =>
         {
             pinchCount++;
         });
@@ -371,7 +371,7 @@ public class GestureSimulatorTests
         Vector? capturedDelta = null;
         int? capturedId = null;
 
-        target.AddHandler(Gestures.ScrollGestureEvent, (sender, args) =>
+        target.AddHandler(InputElement.ScrollGestureEvent, (sender, args) =>
         {
             if (args is ScrollGestureEventArgs scroll)
             {
@@ -400,7 +400,7 @@ public class GestureSimulatorTests
         var simulator = new GestureSimulator();
         int? capturedId = null;
 
-        target.AddHandler(Gestures.ScrollGestureEndedEvent, (sender, args) =>
+        target.AddHandler(InputElement.ScrollGestureEndedEvent, (sender, args) =>
         {
             if (args is ScrollGestureEndedEventArgs scrollEnded)
             {
@@ -429,12 +429,12 @@ public class GestureSimulatorTests
         var scrollCount = 0;
         var scrollEndedRaised = false;
 
-        target.AddHandler(Gestures.ScrollGestureEvent, (sender, args) =>
+        target.AddHandler(InputElement.ScrollGestureEvent, (sender, args) =>
         {
             scrollCount++;
         });
 
-        target.AddHandler(Gestures.ScrollGestureEndedEvent, (sender, args) =>
+        target.AddHandler(InputElement.ScrollGestureEndedEvent, (sender, args) =>
         {
             scrollEndedRaised = true;
         });
@@ -481,7 +481,7 @@ public class GestureSimulatorTests
         Vector? capturedDelta = null;
         PullDirection? capturedDirection = null;
 
-        target.AddHandler(Gestures.PullGestureEvent, (sender, args) =>
+        target.AddHandler(InputElement.PullGestureEvent, (sender, args) =>
         {
             if (args is PullGestureEventArgs pull)
             {
@@ -512,7 +512,7 @@ public class GestureSimulatorTests
         int? capturedId = null;
         PullDirection? capturedDirection = null;
 
-        target.AddHandler(Gestures.PullGestureEndedEvent, (sender, args) =>
+        target.AddHandler(InputElement.PullGestureEndedEvent, (sender, args) =>
         {
             if (args is PullGestureEndedEventArgs pullEnded)
             {
@@ -545,12 +545,12 @@ public class GestureSimulatorTests
         var pullEndedRaised = false;
         PullDirection? pullEndedDirection = null;
 
-        target.AddHandler(Gestures.PullGestureEvent, (sender, args) =>
+        target.AddHandler(InputElement.PullGestureEvent, (sender, args) =>
         {
             pullCount++;
         });
 
-        target.AddHandler(Gestures.PullGestureEndedEvent, (sender, args) =>
+        target.AddHandler(InputElement.PullGestureEndedEvent, (sender, args) =>
         {
             pullEndedRaised = true;
             if (args is PullGestureEndedEventArgs pullEnded)
@@ -583,7 +583,7 @@ public class GestureSimulatorTests
         var simulator = new GestureSimulator();
         var capturedDirections = new List<PullDirection>();
 
-        target.AddHandler(Gestures.PullGestureEvent, (sender, args) =>
+        target.AddHandler(InputElement.PullGestureEvent, (sender, args) =>
         {
             if (args is PullGestureEventArgs pull)
             {
@@ -614,7 +614,7 @@ public class GestureSimulatorTests
         var simulator = new GestureSimulator();
         Vector? capturedDelta = null;
 
-        target.AddHandler(Gestures.PointerTouchPadGestureMagnifyEvent, (sender, args) =>
+        target.AddHandler(InputElement.PointerTouchPadGestureMagnifyEvent, (sender, args) =>
         {
             if (args is PointerDeltaEventArgs delta)
             {
@@ -641,7 +641,7 @@ public class GestureSimulatorTests
         var simulator = new GestureSimulator();
         var eventRaised = false;
 
-        target.AddHandler(Gestures.PointerTouchPadGestureRotateEvent, (sender, args) =>
+        target.AddHandler(InputElement.PointerTouchPadGestureRotateEvent, (sender, args) =>
         {
             eventRaised = true;
         });
@@ -664,7 +664,7 @@ public class GestureSimulatorTests
         var simulator = new GestureSimulator();
         Vector? capturedDelta = null;
 
-        target.AddHandler(Gestures.PointerTouchPadGestureSwipeEvent, (sender, args) =>
+        target.AddHandler(InputElement.PointerTouchPadGestureSwipeEvent, (sender, args) =>
         {
             if (args is PointerDeltaEventArgs delta)
             {
@@ -691,7 +691,7 @@ public class GestureSimulatorTests
         var simulator = new GestureSimulator();
         var magnifyCount = 0;
 
-        target.AddHandler(Gestures.PointerTouchPadGestureMagnifyEvent, (sender, args) =>
+        target.AddHandler(InputElement.PointerTouchPadGestureMagnifyEvent, (sender, args) =>
         {
             magnifyCount++;
         });
@@ -714,13 +714,13 @@ public class GestureSimulatorTests
         var simulator = new GestureSimulator();
         var swipeCount = 0;
 
-        target.AddHandler(Gestures.PointerTouchPadGestureSwipeEvent, (sender, args) =>
+        target.AddHandler(InputElement.PointerTouchPadGestureSwipeEvent, (sender, args) =>
         {
             swipeCount++;
         });
 
         // Act
-        simulator.TouchpadSwipeSequence(target, new Point(50, 50), SwipeDirection.Left, distance: 100, steps: 5);
+        simulator.TouchpadSwipeSequence(target, new Point(50, 50), Avalonia.HeadlessTestingFramework.SwipeDirection.Left, distance: 100, steps: 5);
 
         // Assert
         Assert.Equal(5, swipeCount);
@@ -743,12 +743,12 @@ public class GestureSimulatorTests
         var holdingStarted = false;
         var holdingCompleted = false;
 
-        target.AddHandler(Gestures.TappedEvent, (sender, args) =>
+        target.AddHandler(InputElement.TappedEvent, (sender, args) =>
         {
             tapRaised = true;
         });
 
-        target.AddHandler(Gestures.HoldingEvent, (sender, args) =>
+        target.AddHandler(InputElement.HoldingEvent, (sender, args) =>
         {
             if (args is HoldingRoutedEventArgs holding)
             {
@@ -780,12 +780,12 @@ public class GestureSimulatorTests
         var doubleTapRaised = false;
         var pinchCount = 0;
 
-        target.AddHandler(Gestures.DoubleTappedEvent, (sender, args) =>
+        target.AddHandler(InputElement.DoubleTappedEvent, (sender, args) =>
         {
             doubleTapRaised = true;
         });
 
-        target.AddHandler(Gestures.PinchEvent, (sender, args) =>
+        target.AddHandler(InputElement.PinchEvent, (sender, args) =>
         {
             pinchCount++;
         });
@@ -810,18 +810,18 @@ public class GestureSimulatorTests
         var scrollCount = 0;
         var scrollEndedRaised = false;
 
-        target.AddHandler(Gestures.ScrollGestureEvent, (sender, args) =>
+        target.AddHandler(InputElement.ScrollGestureEvent, (sender, args) =>
         {
             scrollCount++;
         });
 
-        target.AddHandler(Gestures.ScrollGestureEndedEvent, (sender, args) =>
+        target.AddHandler(InputElement.ScrollGestureEndedEvent, (sender, args) =>
         {
             scrollEndedRaised = true;
         });
 
         // Act
-        simulator.Flick(target, SwipeDirection.Up, distance: 50, velocity: 500);
+        simulator.Flick(target, Avalonia.HeadlessTestingFramework.SwipeDirection.Up, distance: 50, velocity: 500);
 
         // Assert
         Assert.True(scrollCount > 0);
@@ -839,13 +839,13 @@ public class GestureSimulatorTests
         var simulator = new GestureSimulator();
         var swipeCount = 0;
 
-        target.AddHandler(Gestures.PointerTouchPadGestureSwipeEvent, (sender, args) =>
+        target.AddHandler(InputElement.PointerTouchPadGestureSwipeEvent, (sender, args) =>
         {
             swipeCount++;
         });
 
         // Act
-        simulator.ThreeFingerSwipe(target, new Point(50, 50), SwipeDirection.Right, distance: 100);
+        simulator.ThreeFingerSwipe(target, new Point(50, 50), Avalonia.HeadlessTestingFramework.SwipeDirection.Right, distance: 100);
 
         // Assert
         Assert.True(swipeCount > 0);

--- a/tests/Avalonia.Controls.PanAndZoom.UnitTests/GestureSimulatorTests.cs
+++ b/tests/Avalonia.Controls.PanAndZoom.UnitTests/GestureSimulatorTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Wiesław Šoltés. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 using System.Collections.Generic;
+using System.Reflection;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using Avalonia.Input;
@@ -250,6 +251,45 @@ public class GestureSimulatorTests
     }
 
     [AvaloniaFact]
+    public void HoldingStarted_UsesPresentationRootCoordinates_ForAncestorLookups()
+    {
+        var target = new Border { Width = 100, Height = 100, Background = Brushes.Red };
+        Canvas.SetLeft(target, 40);
+        Canvas.SetTop(target, 30);
+
+        var canvas = new Canvas { Width = 200, Height = 200 };
+        canvas.Children.Add(target);
+
+        var window = new Window
+        {
+            Width = 300,
+            Height = 300,
+            Content = canvas
+        };
+        window.Show();
+
+        var simulator = new GestureSimulator();
+        PointerEventArgs? capturedPointerEventArgs = null;
+
+        target.AddHandler(InputElement.HoldingEvent, (_, args) =>
+        {
+            if (args is HoldingRoutedEventArgs holding)
+            {
+                capturedPointerEventArgs = GetHoldingPointerEventArgs(holding);
+            }
+        });
+
+        simulator.HoldingStarted(target, new Point(25, 25));
+
+        Assert.NotNull(capturedPointerEventArgs);
+        var expectedCanvasPosition = target.TransformToVisual(canvas)!.Value.Transform(new Point(25, 25));
+        var expectedWindowPosition = target.TransformToVisual(window)!.Value.Transform(new Point(25, 25));
+
+        Assert.Equal(expectedCanvasPosition, capturedPointerEventArgs!.GetPosition(canvas));
+        Assert.Equal(expectedWindowPosition, capturedPointerEventArgs.GetPosition(window));
+    }
+
+    [AvaloniaFact]
     public void HoldingCancelled_RaisesEvent_WithCorrectState()
     {
         // Arrange
@@ -304,7 +344,46 @@ public class GestureSimulatorTests
         Assert.Equal(HoldingState.Completed, states[1]);
     }
 
+    [AvaloniaFact]
+    public void Hold_ReusesTheSamePointerId_AcrossLifecycleEvents()
+    {
+        var target = new Border { Width = 100, Height = 100, Background = Brushes.Red };
+        var window = new Window { Content = target };
+        window.Show();
+
+        var simulator = new GestureSimulator();
+        var pointerIds = new List<int>();
+
+        target.AddHandler(InputElement.HoldingEvent, (_, args) =>
+        {
+            if (args is HoldingRoutedEventArgs holding)
+            {
+                var pointerEventArgs = GetHoldingPointerEventArgs(holding);
+                pointerIds.Add(pointerEventArgs.Pointer.Id);
+            }
+        });
+
+        simulator.Hold(target, new Point(50, 50), holdDuration: 500);
+
+        Assert.Equal(2, pointerIds.Count);
+        Assert.Equal(pointerIds[0], pointerIds[1]);
+    }
+
     #endregion
+
+    private static PointerEventArgs GetHoldingPointerEventArgs(HoldingRoutedEventArgs args)
+    {
+        var pointerEventArgsProperty = typeof(HoldingRoutedEventArgs).GetProperty(
+            "PointerEventArgs",
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+
+        Assert.NotNull(pointerEventArgsProperty);
+
+        var pointerEventArgs = pointerEventArgsProperty!.GetValue(args) as PointerEventArgs;
+        Assert.NotNull(pointerEventArgs);
+
+        return pointerEventArgs!;
+    }
 
     #region Pinch Gesture Tests
 

--- a/tests/Avalonia.Controls.PanAndZoom.UnitTests/RecordedTouchSimulatorTests.cs
+++ b/tests/Avalonia.Controls.PanAndZoom.UnitTests/RecordedTouchSimulatorTests.cs
@@ -323,7 +323,7 @@ public class RecordedTouchSimulatorTests : IDisposable
             var session = simulator.StartRecording(window, outputPath: _testOutputDir);
 
             // Act
-            simulator.RecordedSwipe(window, new Point(100, 150), SwipeDirection.Right, 100);
+            simulator.RecordedSwipe(window, new Point(100, 150), Avalonia.HeadlessTestingFramework.SwipeDirection.Right, 100);
 
             // Assert
             Assert.Contains(session.Events, e => e.EventType == RecordingEventType.Gesture);

--- a/tests/Avalonia.Controls.PanAndZoom.UnitTests/ReflectionDiagnosticTest.cs
+++ b/tests/Avalonia.Controls.PanAndZoom.UnitTests/ReflectionDiagnosticTest.cs
@@ -25,7 +25,7 @@ public class ReflectionDiagnosticTest
         
         // Register handler BEFORE window.Show()
         var pinchEventCount = 0;
-        Gestures.AddPinchHandler(border, (sender, e) => 
+        border.AddHandler(InputElement.PinchEvent, (sender, e) => 
         {
             pinchEventCount++;
         });
@@ -54,7 +54,7 @@ public class ReflectionDiagnosticTest
         
         // Register handler
         var pinchEventCount = 0;
-        Gestures.AddPinchHandler(border, (sender, e) => 
+        border.AddHandler(InputElement.PinchEvent, (sender, e) => 
         {
             pinchEventCount++;
         });
@@ -99,7 +99,7 @@ public class ReflectionDiagnosticTest
         
         // Register handler
         var pinchEventCount = 0;
-        Gestures.AddPinchHandler(zoomBorder, (sender, e) => 
+        zoomBorder.AddHandler(InputElement.PinchEvent, (sender, e) => 
         {
             pinchEventCount++;
         });

--- a/tests/Avalonia.Controls.PanAndZoom.UnitTests/VisualTreeTestHelperTests.cs
+++ b/tests/Avalonia.Controls.PanAndZoom.UnitTests/VisualTreeTestHelperTests.cs
@@ -66,7 +66,7 @@ public class VisualTreeTestHelperTests
             {
                 Children =
                 {
-                    new TextBox { Name = "Input1", Text = "Enter text", Watermark = "Type here" },
+                    new TextBox { Name = "Input1", Text = "Enter text", PlaceholderText = "Type here" },
                     new CheckBox { Name = "Check1", Content = "Accept Terms", IsChecked = true },
                     new ComboBox
                     {

--- a/tests/Avalonia.Controls.PanAndZoom.UnitTests/ZoomBorderAppiumTests.cs
+++ b/tests/Avalonia.Controls.PanAndZoom.UnitTests/ZoomBorderAppiumTests.cs
@@ -385,7 +385,7 @@ public class ZoomBorderAppiumTests
         // Perform swipe using direction enum
         var action = new TouchAction(driver)
             .Press(element)
-            .Swipe(SwipeDirection.Right, 100)
+            .Swipe(Avalonia.HeadlessTestingFramework.SwipeDirection.Right, 100)
             .Release();
 
         action.Perform();

--- a/tests/Avalonia.Controls.PanAndZoom.UnitTests/ZoomBorderConstraintTests.cs
+++ b/tests/Avalonia.Controls.PanAndZoom.UnitTests/ZoomBorderConstraintTests.cs
@@ -133,7 +133,7 @@ public class ZoomBorderConstraintTests
         // Act - Try to zoom beyond maximum with pinch gesture
         var pinchEventArgs = new PinchEventArgs(2.0, new Point(0.5, 0.5), 0.0, 0.0)
         {
-            RoutedEvent = Gestures.PinchEvent,
+            RoutedEvent = InputElement.PinchEvent,
             Source = zoomBorder
         };
         
@@ -177,7 +177,7 @@ public class ZoomBorderConstraintTests
         // Act - Try to zoom below minimum with pinch gesture
         var pinchEventArgs = new PinchEventArgs(0.1, new Point(0.5, 0.5), 0.0, 0.0)
         {
-            RoutedEvent = Gestures.PinchEvent,
+            RoutedEvent = InputElement.PinchEvent,
             Source = zoomBorder
         };
         
@@ -289,7 +289,7 @@ public class ZoomBorderConstraintTests
         // Act - Try to scroll beyond limits
         var scrollEventArgs = new ScrollGestureEventArgs(1, new Vector(100, 100))
         {
-            RoutedEvent = Gestures.ScrollGestureEvent,
+            RoutedEvent = InputElement.ScrollGestureEvent,
             Source = zoomBorder
         };
         
@@ -497,7 +497,7 @@ public class ZoomBorderConstraintTests
             // Pan
             var scrollEventArgs = new ScrollGestureEventArgs(i + 1, new Vector(i % 2 == 0 ? 20 : -20, 0))
             {
-                RoutedEvent = Gestures.ScrollGestureEvent,
+                RoutedEvent = InputElement.ScrollGestureEvent,
                 Source = zoomBorder
             };
             

--- a/tests/Avalonia.Controls.PanAndZoom.UnitTests/ZoomBorderDoubleClickZoomTests.cs
+++ b/tests/Avalonia.Controls.PanAndZoom.UnitTests/ZoomBorderDoubleClickZoomTests.cs
@@ -321,10 +321,10 @@ public class ZoomBorderDoubleClickZoomTests
         // Act - Raise DoubleTapped event
         var pointerArgs = CreatePointerEventArgs(zoomBorder, new Point(200, 200));
         var tappedArgs = new TappedEventArgs(
-            Gestures.DoubleTappedEvent,
+            InputElement.DoubleTappedEvent,
             pointerArgs)
         {
-            RoutedEvent = Gestures.DoubleTappedEvent
+            RoutedEvent = InputElement.DoubleTappedEvent
         };
         zoomBorder.RaiseEvent(tappedArgs);
 
@@ -356,10 +356,10 @@ public class ZoomBorderDoubleClickZoomTests
         // Act - Raise DoubleTapped event
         var pointerArgs = CreatePointerEventArgs(zoomBorder, new Point(200, 200));
         var tappedArgs = new TappedEventArgs(
-            Gestures.DoubleTappedEvent,
+            InputElement.DoubleTappedEvent,
             pointerArgs)
         {
-            RoutedEvent = Gestures.DoubleTappedEvent
+            RoutedEvent = InputElement.DoubleTappedEvent
         };
         zoomBorder.RaiseEvent(tappedArgs);
 
@@ -424,10 +424,10 @@ public class ZoomBorderDoubleClickZoomTests
         // Act - Raise DoubleTapped event
         var pointerArgs = CreatePointerEventArgs(zoomBorder, new Point(200, 200));
         var tappedArgs = new TappedEventArgs(
-            Gestures.DoubleTappedEvent,
+            InputElement.DoubleTappedEvent,
             pointerArgs)
         {
-            RoutedEvent = Gestures.DoubleTappedEvent
+            RoutedEvent = InputElement.DoubleTappedEvent
         };
         zoomBorder.RaiseEvent(tappedArgs);
 
@@ -459,10 +459,10 @@ public class ZoomBorderDoubleClickZoomTests
         // Act - Raise DoubleTapped event
         var pointerArgs = CreatePointerEventArgs(zoomBorder, new Point(200, 200));
         var tappedArgs = new TappedEventArgs(
-            Gestures.DoubleTappedEvent,
+            InputElement.DoubleTappedEvent,
             pointerArgs)
         {
-            RoutedEvent = Gestures.DoubleTappedEvent
+            RoutedEvent = InputElement.DoubleTappedEvent
         };
         zoomBorder.RaiseEvent(tappedArgs);
 
@@ -494,10 +494,10 @@ public class ZoomBorderDoubleClickZoomTests
         // Act - Raise DoubleTapped event
         var pointerArgs = CreatePointerEventArgs(zoomBorder, new Point(200, 200));
         var tappedArgs = new TappedEventArgs(
-            Gestures.DoubleTappedEvent,
+            InputElement.DoubleTappedEvent,
             pointerArgs)
         {
-            RoutedEvent = Gestures.DoubleTappedEvent
+            RoutedEvent = InputElement.DoubleTappedEvent
         };
         zoomBorder.RaiseEvent(tappedArgs);
 
@@ -526,10 +526,10 @@ public class ZoomBorderDoubleClickZoomTests
         // Act - Raise DoubleTapped event
         var pointerArgs = CreatePointerEventArgs(zoomBorder, new Point(200, 200));
         var tappedArgs = new TappedEventArgs(
-            Gestures.DoubleTappedEvent,
+            InputElement.DoubleTappedEvent,
             pointerArgs)
         {
-            RoutedEvent = Gestures.DoubleTappedEvent
+            RoutedEvent = InputElement.DoubleTappedEvent
         };
         zoomBorder.RaiseEvent(tappedArgs);
 

--- a/tests/Avalonia.Controls.PanAndZoom.UnitTests/ZoomBorderGestureRecognizerTests.cs
+++ b/tests/Avalonia.Controls.PanAndZoom.UnitTests/ZoomBorderGestureRecognizerTests.cs
@@ -101,7 +101,7 @@ public class ZoomBorderGestureRecognizerTests
         
         // Register handler BEFORE window.Show()
         var pinchEventCount = 0;
-        Gestures.AddPinchHandler(zoomBorder, (sender, e) => 
+        zoomBorder.AddHandler(InputElement.PinchEvent, (sender, e) => 
         {
             pinchEventCount++;
         });
@@ -159,7 +159,7 @@ public class ZoomBorderGestureRecognizerTests
         // Arrange - register handler before show
         var pinchRaised = false;
         var (zoomBorder, _) = SetupZoomBorderWithWindow(zb => 
-            Gestures.AddPinchHandler(zb, (s, e) => pinchRaised = true));
+            zb.AddHandler(InputElement.PinchEvent, (s, e) => pinchRaised = true));
 
         var touch = new GestureRecognizerTestHelper();
 
@@ -178,7 +178,7 @@ public class ZoomBorderGestureRecognizerTests
         // Arrange - register handler before show
         var pinchRaised = false;
         var (zoomBorder, _) = SetupZoomBorderWithWindow(zb => 
-            Gestures.AddPinchHandler(zb, (s, e) => pinchRaised = true));
+            zb.AddHandler(InputElement.PinchEvent, (s, e) => pinchRaised = true));
 
         var touch = new GestureRecognizerTestHelper();
 
@@ -197,7 +197,7 @@ public class ZoomBorderGestureRecognizerTests
         // Arrange - register handler before show
         var pinchEventArgs = new List<PinchEventArgs>();
         var (zoomBorder, _) = SetupZoomBorderWithWindow(zb => 
-            Gestures.AddPinchHandler(zb, (s, e) => pinchEventArgs.Add(e)));
+            zb.AddHandler(InputElement.PinchEvent, (s, e) => pinchEventArgs.Add(e)));
 
         var firstTouch = new GestureRecognizerTestHelper();
         var secondTouch = new GestureRecognizerTestHelper();
@@ -221,7 +221,7 @@ public class ZoomBorderGestureRecognizerTests
         // Arrange - register handler before show
         var pinchEventArgs = new List<PinchEventArgs>();
         var (zoomBorder, _) = SetupZoomBorderWithWindow(zb => 
-            Gestures.AddPinchHandler(zb, (s, e) => pinchEventArgs.Add(e)));
+            zb.AddHandler(InputElement.PinchEvent, (s, e) => pinchEventArgs.Add(e)));
 
         var firstTouch = new GestureRecognizerTestHelper();
         var secondTouch = new GestureRecognizerTestHelper();
@@ -245,7 +245,7 @@ public class ZoomBorderGestureRecognizerTests
         // Arrange - register handler before show
         var pinchEventArgs = new List<PinchEventArgs>();
         var (zoomBorder, _) = SetupZoomBorderWithWindow(zb => 
-            Gestures.AddPinchHandler(zb, (s, e) => pinchEventArgs.Add(e)));
+            zb.AddHandler(InputElement.PinchEvent, (s, e) => pinchEventArgs.Add(e)));
 
         var firstTouch = new GestureRecognizerTestHelper();
         var secondTouch = new GestureRecognizerTestHelper();
@@ -270,7 +270,7 @@ public class ZoomBorderGestureRecognizerTests
         // Arrange - register handler before show
         var pinchEndedRaised = false;
         var (zoomBorder, _) = SetupZoomBorderWithWindow(zb => 
-            zb.AddHandler(Gestures.PinchEndedEvent, (_, _) => pinchEndedRaised = true));
+            zb.AddHandler(InputElement.PinchEndedEvent, (_, _) => pinchEndedRaised = true));
 
         var firstTouch = new GestureRecognizerTestHelper();
         var secondTouch = new GestureRecognizerTestHelper();
@@ -293,7 +293,7 @@ public class ZoomBorderGestureRecognizerTests
         ShowInWindow(zoomBorder);
         var pinchEndedRaised = false;
 
-        zoomBorder.AddHandler(Gestures.PinchEndedEvent, (_, _) => pinchEndedRaised = true);
+        zoomBorder.AddHandler(InputElement.PinchEndedEvent, (_, _) => pinchEndedRaised = true);
 
         var firstTouch = new GestureRecognizerTestHelper();
         var secondTouch = new GestureRecognizerTestHelper();
@@ -319,7 +319,7 @@ public class ZoomBorderGestureRecognizerTests
         // Arrange - register handler before show
         var pinchCount = 0;
         var (zoomBorder, _) = SetupZoomBorderWithWindow(zb => 
-            Gestures.AddPinchHandler(zb, (s, e) => pinchCount++));
+            zb.AddHandler(InputElement.PinchEvent, (s, e) => pinchCount++));
 
         // Act - First pinch
         var first1 = new GestureRecognizerTestHelper();
@@ -357,7 +357,7 @@ public class ZoomBorderGestureRecognizerTests
         // Arrange - register handler before show
         var scrollRaised = false;
         var (zoomBorder, _) = SetupZoomBorderWithWindow(zb => 
-            zb.AddHandler(Gestures.ScrollGestureEvent, (_, _) => scrollRaised = true));
+            zb.AddHandler(InputElement.ScrollGestureEvent, (_, _) => scrollRaised = true));
 
         var touch = new GestureRecognizerTestHelper();
 
@@ -378,7 +378,7 @@ public class ZoomBorderGestureRecognizerTests
         ShowInWindow(zoomBorder);
         var scrollRaised = false;
 
-        zoomBorder.AddHandler(Gestures.ScrollGestureEvent, (_, _) => scrollRaised = true);
+        zoomBorder.AddHandler(InputElement.ScrollGestureEvent, (_, _) => scrollRaised = true);
 
         var touch = new GestureRecognizerTestHelper();
 
@@ -399,7 +399,7 @@ public class ZoomBorderGestureRecognizerTests
         ShowInWindow(zoomBorder);
         
         var scrollEventArgs = new List<ScrollGestureEventArgs>();
-        zoomBorder.AddHandler(Gestures.ScrollGestureEvent, (_, e) => scrollEventArgs.Add(e));
+        zoomBorder.AddHandler(InputElement.ScrollGestureEvent, (_, e) => scrollEventArgs.Add(e));
 
         var touch = new GestureRecognizerTestHelper();
 
@@ -425,7 +425,7 @@ public class ZoomBorderGestureRecognizerTests
         ShowInWindow(zoomBorder);
         
         var scrollEventArgs = new List<ScrollGestureEventArgs>();
-        zoomBorder.AddHandler(Gestures.ScrollGestureEvent, (_, e) => scrollEventArgs.Add(e));
+        zoomBorder.AddHandler(InputElement.ScrollGestureEvent, (_, e) => scrollEventArgs.Add(e));
 
         var touch = new GestureRecognizerTestHelper();
 
@@ -449,7 +449,7 @@ public class ZoomBorderGestureRecognizerTests
         // Arrange - register handler before show
         var scrollEndedRaised = false;
         var (zoomBorder, _) = SetupZoomBorderWithWindow(zb => 
-            zb.AddHandler(Gestures.ScrollGestureEndedEvent, (_, _) => scrollEndedRaised = true));
+            zb.AddHandler(InputElement.ScrollGestureEndedEvent, (_, _) => scrollEndedRaised = true));
 
         var touch = new GestureRecognizerTestHelper();
 
@@ -469,7 +469,7 @@ public class ZoomBorderGestureRecognizerTests
         // Arrange - register handler before show
         var scrollRaised = false;
         var (zoomBorder, _) = SetupZoomBorderWithWindow(zb => 
-            zb.AddHandler(Gestures.ScrollGestureEvent, (_, _) => scrollRaised = true));
+            zb.AddHandler(InputElement.ScrollGestureEvent, (_, _) => scrollRaised = true));
 
         // Use a mouse pointer instead of touch
         var mouse = new GestureRecognizerTestHelper(PointerType.Mouse);
@@ -490,7 +490,7 @@ public class ZoomBorderGestureRecognizerTests
         // Arrange - register handler before show
         var scrollRaised = false;
         var (zoomBorder, _) = SetupZoomBorderWithWindow(zb => 
-            zb.AddHandler(Gestures.ScrollGestureEvent, (_, _) => scrollRaised = true));
+            zb.AddHandler(InputElement.ScrollGestureEvent, (_, _) => scrollRaised = true));
 
         // Use a pen pointer
         var pen = new GestureRecognizerTestHelper(PointerType.Pen);
@@ -660,7 +660,7 @@ public class ZoomBorderGestureRecognizerTests
         // Arrange - register handler before show
         var pinchRaised = false;
         var (zoomBorder, _) = SetupZoomBorderWithWindow(zb => 
-            Gestures.AddPinchHandler(zb, (s, e) => pinchRaised = true));
+            zb.AddHandler(InputElement.PinchEvent, (s, e) => pinchRaised = true));
 
         // Act
         MultiTouchTestHelperFactory.SimulatePinch(
@@ -681,7 +681,7 @@ public class ZoomBorderGestureRecognizerTests
         // Arrange - register handler before show
         var pinchEventArgs = new List<PinchEventArgs>();
         var (zoomBorder, _) = SetupZoomBorderWithWindow(zb => 
-            Gestures.AddPinchHandler(zb, (s, e) => pinchEventArgs.Add(e)));
+            zb.AddHandler(InputElement.PinchEvent, (s, e) => pinchEventArgs.Add(e)));
 
         // Act
         MultiTouchTestHelperFactory.SimulatePinchZoomIn(
@@ -702,7 +702,7 @@ public class ZoomBorderGestureRecognizerTests
         // Arrange - register handler before show
         var pinchEventArgs = new List<PinchEventArgs>();
         var (zoomBorder, _) = SetupZoomBorderWithWindow(zb => 
-            Gestures.AddPinchHandler(zb, (s, e) => pinchEventArgs.Add(e)));
+            zb.AddHandler(InputElement.PinchEvent, (s, e) => pinchEventArgs.Add(e)));
 
         // Act
         MultiTouchTestHelperFactory.SimulatePinchZoomOut(
@@ -723,7 +723,7 @@ public class ZoomBorderGestureRecognizerTests
         // Arrange - register handler before show
         var pinchRaised = false;
         var (zoomBorder, _) = SetupZoomBorderWithWindow(zb => 
-            Gestures.AddPinchHandler(zb, (s, e) => pinchRaised = true));
+            zb.AddHandler(InputElement.PinchEvent, (s, e) => pinchRaised = true));
 
         // Act
         MultiTouchTestHelperFactory.SimulateTwoFingerPan(
@@ -743,7 +743,7 @@ public class ZoomBorderGestureRecognizerTests
         // Arrange - register handler before show
         var pinchEventArgs = new List<PinchEventArgs>();
         var (zoomBorder, _) = SetupZoomBorderWithWindow(zb => 
-            Gestures.AddPinchHandler(zb, (s, e) => pinchEventArgs.Add(e)));
+            zb.AddHandler(InputElement.PinchEvent, (s, e) => pinchEventArgs.Add(e)));
 
         // Act
         MultiTouchTestHelperFactory.SimulateRotation(
@@ -872,7 +872,7 @@ public class ZoomBorderGestureRecognizerTests
         // Arrange - register handler before show
         var scrollRaised = false;
         var (zoomBorder, _) = SetupZoomBorderWithWindow(zb => 
-            zb.AddHandler(Gestures.ScrollGestureEvent, (_, _) => scrollRaised = true));
+            zb.AddHandler(InputElement.ScrollGestureEvent, (_, _) => scrollRaised = true));
 
         var helper = new GestureRecognizerTestHelper();
 
@@ -925,7 +925,7 @@ public class ZoomBorderGestureRecognizerTests
         ShowInWindow(zoomBorder);
         var pinchCount = 0;
 
-        Gestures.AddPinchHandler(zoomBorder, (s, e) => pinchCount++);
+        zoomBorder.AddHandler(InputElement.PinchEvent, (s, e) => pinchCount++);
 
         var first = new GestureRecognizerTestHelper();
         var second = new GestureRecognizerTestHelper();
@@ -972,8 +972,8 @@ public class ZoomBorderGestureRecognizerTests
         var pinchRaised = false;
         var scrollRaised = false;
         var (zoomBorder, _) = SetupZoomBorderWithWindow(zb => {
-            Gestures.AddPinchHandler(zb, (s, e) => pinchRaised = true);
-            zb.AddHandler(Gestures.ScrollGestureEvent, (_, _) => scrollRaised = true);
+            zb.AddHandler(InputElement.PinchEvent, (s, e) => pinchRaised = true);
+            zb.AddHandler(InputElement.ScrollGestureEvent, (_, _) => scrollRaised = true);
         });
 
         // Act - First do a pinch
@@ -1015,7 +1015,7 @@ public class ZoomBorderGestureRecognizerTests
         zoomBorder.Child = new Border { Width = 200, Height = 150, Background = Brushes.Red };
         
         var pinchCount = 0;
-        Gestures.AddPinchHandler(zoomBorder, (s, e) => pinchCount++);
+        zoomBorder.AddHandler(InputElement.PinchEvent, (s, e) => pinchCount++);
         
         var window = new Window { Content = zoomBorder };
         window.Show();
@@ -1047,7 +1047,7 @@ public class ZoomBorderGestureRecognizerTests
         // Arrange - register handler before show
         var pinchRaised = false;
         var (zoomBorder, _) = SetupZoomBorderWithWindow(zb => 
-            Gestures.AddPinchHandler(zb, (s, e) => pinchRaised = true));
+            zb.AddHandler(InputElement.PinchEvent, (s, e) => pinchRaised = true));
         zoomBorder.MinimumTouchPoints = 2;
 
         // Act - Single finger (below minimum)
@@ -1066,7 +1066,7 @@ public class ZoomBorderGestureRecognizerTests
         // Arrange - register handler before show
         var pinchCount = 0;
         var (zoomBorder, _) = SetupZoomBorderWithWindow(zb => 
-            Gestures.AddPinchHandler(zb, (s, e) => pinchCount++));
+            zb.AddHandler(InputElement.PinchEvent, (s, e) => pinchCount++));
         zoomBorder.MaximumTouchPoints = 2;
 
         // Act - Three fingers

--- a/tests/Avalonia.Controls.PanAndZoom.UnitTests/ZoomBorderGestureToggleTests.cs
+++ b/tests/Avalonia.Controls.PanAndZoom.UnitTests/ZoomBorderGestureToggleTests.cs
@@ -85,7 +85,7 @@ public class ZoomBorderGestureToggleTests
         // Act - Simulate pinch gesture when gesture zoom is disabled
         var pinchEventArgs = new PinchEventArgs(1.5, new Point(0.5, 0.5), 0.0, 0.0)
         {
-            RoutedEvent = Gestures.PinchEvent,
+            RoutedEvent = InputElement.PinchEvent,
             Source = zoomBorder
         };
         
@@ -126,7 +126,7 @@ public class ZoomBorderGestureToggleTests
         // Act - Simulate scroll gesture when gesture pan is disabled
         var scrollEventArgs = new ScrollGestureEventArgs(1, new Vector(50, 50))
         {
-            RoutedEvent = Gestures.ScrollGestureEvent,
+            RoutedEvent = InputElement.ScrollGestureEvent,
             Source = zoomBorder
         };
         

--- a/tests/Avalonia.Controls.PanAndZoom.UnitTests/ZoomBorderInteractionScenarioTests.cs
+++ b/tests/Avalonia.Controls.PanAndZoom.UnitTests/ZoomBorderInteractionScenarioTests.cs
@@ -139,7 +139,7 @@ public class ZoomBorderInteractionScenarioTests
             0.0,
             0.0)
         {
-            RoutedEvent = Gestures.PinchEvent,
+            RoutedEvent = InputElement.PinchEvent,
             Source = zoomBorder
         };
         
@@ -182,7 +182,7 @@ public class ZoomBorderInteractionScenarioTests
         // Act - First use scroll gesture for panning
         var scrollEventArgs = new ScrollGestureEventArgs(1, new Vector(50, 0))
         {
-            RoutedEvent = Gestures.ScrollGestureEvent,
+            RoutedEvent = InputElement.ScrollGestureEvent,
             Source = zoomBorder
         };
         
@@ -431,7 +431,7 @@ public class ZoomBorderInteractionScenarioTests
             0.0,
             0.0)
         {
-            RoutedEvent = Gestures.PinchEvent,
+            RoutedEvent = InputElement.PinchEvent,
             Source = zoomBorder
         };
         
@@ -497,7 +497,7 @@ public class ZoomBorderInteractionScenarioTests
                 0.0,
                 0.0)
             {
-                RoutedEvent = Gestures.PinchEvent,
+                RoutedEvent = InputElement.PinchEvent,
                 Source = zoomBorder
             };
             

--- a/tests/Avalonia.Controls.PanAndZoom.UnitTests/ZoomBorderMultiTouchTests.cs
+++ b/tests/Avalonia.Controls.PanAndZoom.UnitTests/ZoomBorderMultiTouchTests.cs
@@ -211,7 +211,7 @@ public class ZoomBorderMultiTouchTests
         // Act - Simulate pinch gesture
         var pinchEventArgs = new PinchEventArgs(1.5, new Point(0.5, 0.5), 0.0, 0.0)
         {
-            RoutedEvent = Gestures.PinchEvent,
+            RoutedEvent = InputElement.PinchEvent,
             Source = zoomBorder
         };
 
@@ -251,7 +251,7 @@ public class ZoomBorderMultiTouchTests
         // Act - Simulate pinch gesture
         var pinchEventArgs = new PinchEventArgs(1.5, new Point(0.5, 0.5), 0.0, 0.0)
         {
-            RoutedEvent = Gestures.PinchEvent,
+            RoutedEvent = InputElement.PinchEvent,
             Source = zoomBorder
         };
 
@@ -292,7 +292,7 @@ public class ZoomBorderMultiTouchTests
         // Act - Simulate pinch gesture
         var pinchEventArgs = new PinchEventArgs(1.5, new Point(0.5, 0.5), 0.0, 0.0)
         {
-            RoutedEvent = Gestures.PinchEvent,
+            RoutedEvent = InputElement.PinchEvent,
             Source = zoomBorder
         };
 
@@ -336,7 +336,7 @@ public class ZoomBorderMultiTouchTests
         // Act - Simulate scroll gesture
         var scrollEventArgs = new ScrollGestureEventArgs(1, new Vector(50, 0))
         {
-            RoutedEvent = Gestures.ScrollGestureEvent,
+            RoutedEvent = InputElement.ScrollGestureEvent,
             Source = zoomBorder
         };
 
@@ -376,7 +376,7 @@ public class ZoomBorderMultiTouchTests
         // Act - Simulate scroll gesture
         var scrollEventArgs = new ScrollGestureEventArgs(1, new Vector(50, 0))
         {
-            RoutedEvent = Gestures.ScrollGestureEvent,
+            RoutedEvent = InputElement.ScrollGestureEvent,
             Source = zoomBorder
         };
 
@@ -417,7 +417,7 @@ public class ZoomBorderMultiTouchTests
         // Act - Simulate scroll gesture
         var scrollEventArgs = new ScrollGestureEventArgs(1, new Vector(50, 0))
         {
-            RoutedEvent = Gestures.ScrollGestureEvent,
+            RoutedEvent = InputElement.ScrollGestureEvent,
             Source = zoomBorder
         };
 
@@ -461,7 +461,7 @@ public class ZoomBorderMultiTouchTests
         // Act - Send first pinch gesture (should be ignored due to delay)
         var pinchEventArgs = new PinchEventArgs(1.5, new Point(0.5, 0.5), 0.0, 0.0)
         {
-            RoutedEvent = Gestures.PinchEvent,
+            RoutedEvent = InputElement.PinchEvent,
             Source = zoomBorder
         };
 
@@ -501,7 +501,7 @@ public class ZoomBorderMultiTouchTests
         // Act - Send pinch gesture
         var pinchEventArgs = new PinchEventArgs(1.5, new Point(0.5, 0.5), 0.0, 0.0)
         {
-            RoutedEvent = Gestures.PinchEvent,
+            RoutedEvent = InputElement.PinchEvent,
             Source = zoomBorder
         };
 

--- a/tests/Avalonia.Controls.PanAndZoom.UnitTests/ZoomBorderPinchGestureTests.cs
+++ b/tests/Avalonia.Controls.PanAndZoom.UnitTests/ZoomBorderPinchGestureTests.cs
@@ -37,7 +37,7 @@ public class ZoomBorderPinchGestureTests
         // Act - Simulate pinch gesture with scale > 1 (zoom in)
         var pinchEventArgs = new PinchEventArgs(1.5, new Point(0.5, 0.5), 0.0, 0.0)
         {
-            RoutedEvent = Gestures.PinchEvent,
+            RoutedEvent = InputElement.PinchEvent,
             Source = zoomBorder
         };
         
@@ -82,7 +82,7 @@ public class ZoomBorderPinchGestureTests
         // Act - Simulate pinch gesture with scale < 1 (zoom out)
         var pinchEventArgs = new PinchEventArgs(0.8, new Point(0.5, 0.5), 0.0, 0.0)
         {
-            RoutedEvent = Gestures.PinchEvent,
+            RoutedEvent = InputElement.PinchEvent,
             Source = zoomBorder
         };
         
@@ -123,7 +123,7 @@ public class ZoomBorderPinchGestureTests
         // Act - Simulate pinch gesture at top-left corner
         var pinchEventArgs = new PinchEventArgs(1.5, new Point(0.0, 0.0), 0.0, 0.0)
         {
-            RoutedEvent = Gestures.PinchEvent,
+            RoutedEvent = InputElement.PinchEvent,
             Source = zoomBorder
         };
         
@@ -168,7 +168,7 @@ public class ZoomBorderPinchGestureTests
         // Act - Simulate pinch gesture when gesture zoom is disabled
         var pinchEventArgs = new PinchEventArgs(1.5, new Point(0.5, 0.5), 0.0, 0.0)
         {
-            RoutedEvent = Gestures.PinchEvent,
+            RoutedEvent = InputElement.PinchEvent,
             Source = zoomBorder
         };
         
@@ -200,7 +200,7 @@ public class ZoomBorderPinchGestureTests
         // Act - Simulate pinch gesture without child element
         var pinchEventArgs = new PinchEventArgs(1.5, new Point(0.5, 0.5), 0.0, 0.0)
         {
-            RoutedEvent = Gestures.PinchEvent,
+            RoutedEvent = InputElement.PinchEvent,
             Source = zoomBorder
         };
         
@@ -238,7 +238,7 @@ public class ZoomBorderPinchGestureTests
         // Act - Simulate pinch gesture ended
         var pinchEndedEventArgs = new PinchEndedEventArgs
         {
-            RoutedEvent = Gestures.PinchEndedEvent,
+            RoutedEvent = InputElement.PinchEndedEvent,
             Source = zoomBorder
         };
         
@@ -277,7 +277,7 @@ public class ZoomBorderPinchGestureTests
         // Act - Simulate multiple pinch gestures
         var pinchEventArgs1 = new PinchEventArgs(1.2, new Point(0.5, 0.5), 0.0, 0.0)
         {
-            RoutedEvent = Gestures.PinchEvent,
+            RoutedEvent = InputElement.PinchEvent,
             Source = zoomBorder
         };
         
@@ -286,7 +286,7 @@ public class ZoomBorderPinchGestureTests
         
         var pinchEventArgs2 = new PinchEventArgs(1.3, new Point(0.5, 0.5), 0.0, 0.0)
         {
-            RoutedEvent = Gestures.PinchEvent,
+            RoutedEvent = InputElement.PinchEvent,
             Source = zoomBorder
         };
         
@@ -327,7 +327,7 @@ public class ZoomBorderPinchGestureTests
         // Act - Simulate pinch gesture with scale = 1 (no change)
         var pinchEventArgs = new PinchEventArgs(1.0, new Point(0.5, 0.5), 0.0, 0.0)
         {
-            RoutedEvent = Gestures.PinchEvent,
+            RoutedEvent = InputElement.PinchEvent,
             Source = zoomBorder
         };
         

--- a/tests/Avalonia.Controls.PanAndZoom.UnitTests/ZoomBorderRecordingTests.cs
+++ b/tests/Avalonia.Controls.PanAndZoom.UnitTests/ZoomBorderRecordingTests.cs
@@ -331,16 +331,16 @@ public class ZoomBorderRecordingTests : IDisposable
 
             // Act - Swipe in all directions
             simulator.AddMarker("SwipeRight");
-            simulator.RecordedSwipe(zoomBorder, center, SwipeDirection.Right, 80);
+            simulator.RecordedSwipe(zoomBorder, center, Avalonia.HeadlessTestingFramework.SwipeDirection.Right, 80);
 
             simulator.AddMarker("SwipeLeft");
-            simulator.RecordedSwipe(zoomBorder, center, SwipeDirection.Left, 80);
+            simulator.RecordedSwipe(zoomBorder, center, Avalonia.HeadlessTestingFramework.SwipeDirection.Left, 80);
 
             simulator.AddMarker("SwipeUp");
-            simulator.RecordedSwipe(zoomBorder, center, SwipeDirection.Up, 80);
+            simulator.RecordedSwipe(zoomBorder, center, Avalonia.HeadlessTestingFramework.SwipeDirection.Up, 80);
 
             simulator.AddMarker("SwipeDown");
-            simulator.RecordedSwipe(zoomBorder, center, SwipeDirection.Down, 80);
+            simulator.RecordedSwipe(zoomBorder, center, Avalonia.HeadlessTestingFramework.SwipeDirection.Down, 80);
 
             var stats = simulator.StopRecording();
 

--- a/tests/Avalonia.Controls.PanAndZoom.UnitTests/ZoomBorderScrollGestureTests.cs
+++ b/tests/Avalonia.Controls.PanAndZoom.UnitTests/ZoomBorderScrollGestureTests.cs
@@ -36,7 +36,7 @@ public class ZoomBorderScrollGestureTests
         // Act - Simulate scroll gesture to the right
         var scrollEventArgs = new ScrollGestureEventArgs(1, new Vector(50, 0))
         {
-            RoutedEvent = Gestures.ScrollGestureEvent,
+            RoutedEvent = InputElement.ScrollGestureEvent,
             Source = zoomBorder
         };
         
@@ -76,7 +76,7 @@ public class ZoomBorderScrollGestureTests
         // Act - Simulate scroll gesture to the left
         var scrollEventArgs = new ScrollGestureEventArgs(1, new Vector(-30, 0))
         {
-            RoutedEvent = Gestures.ScrollGestureEvent,
+            RoutedEvent = InputElement.ScrollGestureEvent,
             Source = zoomBorder
         };
         
@@ -116,7 +116,7 @@ public class ZoomBorderScrollGestureTests
         // Act - Simulate scroll gesture upward
         var scrollEventArgs = new ScrollGestureEventArgs(1, new Vector(0, -25))
         {
-            RoutedEvent = Gestures.ScrollGestureEvent,
+            RoutedEvent = InputElement.ScrollGestureEvent,
             Source = zoomBorder
         };
         
@@ -156,7 +156,7 @@ public class ZoomBorderScrollGestureTests
         // Act - Simulate scroll gesture downward
         var scrollEventArgs = new ScrollGestureEventArgs(1, new Vector(0, 40))
         {
-            RoutedEvent = Gestures.ScrollGestureEvent,
+            RoutedEvent = InputElement.ScrollGestureEvent,
             Source = zoomBorder
         };
         
@@ -197,7 +197,7 @@ public class ZoomBorderScrollGestureTests
         // Act - Simulate diagonal scroll gesture
         var scrollEventArgs = new ScrollGestureEventArgs(1, new Vector(30, 40))
         {
-            RoutedEvent = Gestures.ScrollGestureEvent,
+            RoutedEvent = InputElement.ScrollGestureEvent,
             Source = zoomBorder
         };
         
@@ -239,7 +239,7 @@ public class ZoomBorderScrollGestureTests
         // Act - Simulate scroll gesture when gesture pan is disabled
         var scrollEventArgs = new ScrollGestureEventArgs(1, new Vector(50, 50))
         {
-            RoutedEvent = Gestures.ScrollGestureEvent,
+            RoutedEvent = InputElement.ScrollGestureEvent,
             Source = zoomBorder
         };
         
@@ -271,7 +271,7 @@ public class ZoomBorderScrollGestureTests
         // Act - Simulate scroll gesture without child element
         var scrollEventArgs = new ScrollGestureEventArgs(1, new Vector(50, 50))
         {
-            RoutedEvent = Gestures.ScrollGestureEvent,
+            RoutedEvent = InputElement.ScrollGestureEvent,
             Source = zoomBorder
         };
         
@@ -309,7 +309,7 @@ public class ZoomBorderScrollGestureTests
         // Act - Simulate scroll gesture ended
         var scrollEndedEventArgs = new ScrollGestureEndedEventArgs(1)
         {
-            RoutedEvent = Gestures.ScrollGestureEndedEvent,
+            RoutedEvent = InputElement.ScrollGestureEndedEvent,
             Source = zoomBorder
         };
         
@@ -348,7 +348,7 @@ public class ZoomBorderScrollGestureTests
         // Act - Simulate multiple scroll gestures
         var scrollEventArgs1 = new ScrollGestureEventArgs(1, new Vector(20, 0))
         {
-            RoutedEvent = Gestures.ScrollGestureEvent,
+            RoutedEvent = InputElement.ScrollGestureEvent,
             Source = zoomBorder
         };
         
@@ -357,7 +357,7 @@ public class ZoomBorderScrollGestureTests
         
         var scrollEventArgs2 = new ScrollGestureEventArgs(1, new Vector(30, 0))
         {
-            RoutedEvent = Gestures.ScrollGestureEvent,
+            RoutedEvent = InputElement.ScrollGestureEvent,
             Source = zoomBorder
         };
         
@@ -400,7 +400,7 @@ public class ZoomBorderScrollGestureTests
         // Act - Simulate scroll gesture with zero delta
         var scrollEventArgs = new ScrollGestureEventArgs(1, new Vector(0, 0))
         {
-            RoutedEvent = Gestures.ScrollGestureEvent,
+            RoutedEvent = InputElement.ScrollGestureEvent,
             Source = zoomBorder
         };
         

--- a/tests/Avalonia.Controls.PanAndZoom.UnitTests/ZoomBorderTouchGestureComprehensiveTests.cs
+++ b/tests/Avalonia.Controls.PanAndZoom.UnitTests/ZoomBorderTouchGestureComprehensiveTests.cs
@@ -977,7 +977,7 @@ public class ZoomBorderTouchGestureComprehensiveTests
         zoomBorder.PointerReleased += (_, _) => released = true;
 
         // Act
-        simulator.Swipe(zoomBorder, new Point(300, 150), SwipeDirection.Left, 100);
+        simulator.Swipe(zoomBorder, new Point(300, 150), Avalonia.HeadlessTestingFramework.SwipeDirection.Left, 100);
 
         // Assert
         Assert.True(pressed);
@@ -998,7 +998,7 @@ public class ZoomBorderTouchGestureComprehensiveTests
         zoomBorder.PointerReleased += (_, _) => released = true;
 
         // Act
-        simulator.Swipe(zoomBorder, new Point(100, 150), SwipeDirection.Right, 100);
+        simulator.Swipe(zoomBorder, new Point(100, 150), Avalonia.HeadlessTestingFramework.SwipeDirection.Right, 100);
 
         // Assert
         Assert.True(pressed);
@@ -1019,7 +1019,7 @@ public class ZoomBorderTouchGestureComprehensiveTests
         zoomBorder.PointerReleased += (_, _) => released = true;
 
         // Act
-        simulator.Swipe(zoomBorder, new Point(200, 250), SwipeDirection.Up, 100);
+        simulator.Swipe(zoomBorder, new Point(200, 250), Avalonia.HeadlessTestingFramework.SwipeDirection.Up, 100);
 
         // Assert
         Assert.True(pressed);
@@ -1040,7 +1040,7 @@ public class ZoomBorderTouchGestureComprehensiveTests
         zoomBorder.PointerReleased += (_, _) => released = true;
 
         // Act
-        simulator.Swipe(zoomBorder, new Point(200, 50), SwipeDirection.Down, 100);
+        simulator.Swipe(zoomBorder, new Point(200, 50), Avalonia.HeadlessTestingFramework.SwipeDirection.Down, 100);
 
         // Assert
         Assert.True(pressed);

--- a/tests/Avalonia.Controls.PanAndZoom.UnitTests/ZoomBorderTouchSimulatorTests.cs
+++ b/tests/Avalonia.Controls.PanAndZoom.UnitTests/ZoomBorderTouchSimulatorTests.cs
@@ -537,7 +537,7 @@ public class ZoomBorderTouchSimulatorTests
         zoomBorder.PointerReleased += (_, _) => releasedRaised = true;
 
         // Act
-        simulator.Swipe(zoomBorder, new Point(200, 150), SwipeDirection.Left, 100, 100);
+        simulator.Swipe(zoomBorder, new Point(200, 150), Avalonia.HeadlessTestingFramework.SwipeDirection.Left, 100, 100);
 
         // Assert
         Assert.True(pressedRaised, "PointerPressed should be raised");
@@ -570,10 +570,10 @@ public class ZoomBorderTouchSimulatorTests
         var simulator = new TouchInputSimulator();
 
         // Act & Assert - all directions should work without errors
-        simulator.Swipe(zoomBorder, new Point(200, 150), SwipeDirection.Left);
-        simulator.Swipe(zoomBorder, new Point(200, 150), SwipeDirection.Right);
-        simulator.Swipe(zoomBorder, new Point(200, 150), SwipeDirection.Up);
-        simulator.Swipe(zoomBorder, new Point(200, 150), SwipeDirection.Down);
+        simulator.Swipe(zoomBorder, new Point(200, 150), Avalonia.HeadlessTestingFramework.SwipeDirection.Left);
+        simulator.Swipe(zoomBorder, new Point(200, 150), Avalonia.HeadlessTestingFramework.SwipeDirection.Right);
+        simulator.Swipe(zoomBorder, new Point(200, 150), Avalonia.HeadlessTestingFramework.SwipeDirection.Up);
+        simulator.Swipe(zoomBorder, new Point(200, 150), Avalonia.HeadlessTestingFramework.SwipeDirection.Down);
 
         Assert.True(true, "All swipe directions should complete without errors");
     }

--- a/tests/Avalonia.Controls.PanAndZoom.UnitTests/ZoomBorderVisualTreeLifecycleTests.cs
+++ b/tests/Avalonia.Controls.PanAndZoom.UnitTests/ZoomBorderVisualTreeLifecycleTests.cs
@@ -218,7 +218,7 @@ public class ZoomBorderVisualTreeLifecycleTests
         // Test gesture functionality
         var pinchEventArgs = new PinchEventArgs(1.5, new Point(0.5, 0.5), 0.0, 0.0)
         {
-            RoutedEvent = Gestures.PinchEvent,
+            RoutedEvent = InputElement.PinchEvent,
             Source = zoomBorder
         };
         
@@ -269,7 +269,7 @@ public class ZoomBorderVisualTreeLifecycleTests
         // The count might remain the same but they should be new instances
         var pinchEventArgs = new PinchEventArgs(1.5, new Point(0.5, 0.5), 0.0, 0.0)
         {
-            RoutedEvent = Gestures.PinchEvent,
+            RoutedEvent = InputElement.PinchEvent,
             Source = zoomBorder
         };
         

--- a/tests/HeadlessTestingFramework.UnitTests/TouchInputSimulatorTests.cs
+++ b/tests/HeadlessTestingFramework.UnitTests/TouchInputSimulatorTests.cs
@@ -343,7 +343,7 @@ public class TouchInputSimulatorTests
         double? receivedScale = null;
         Point? receivedOrigin = null;
 
-        border.AddHandler(Gestures.PinchEvent, (object? s, PinchEventArgs e) =>
+        border.AddHandler(InputElement.PinchEvent, (object? s, PinchEventArgs e) =>
         {
             eventRaised = true;
             receivedScale = e.Scale;
@@ -369,7 +369,7 @@ public class TouchInputSimulatorTests
         double receivedScale = 0;
         Point? receivedOrigin = null;
 
-        border.AddHandler(Gestures.PinchEvent, (object? s, PinchEventArgs e) =>
+        border.AddHandler(InputElement.PinchEvent, (object? s, PinchEventArgs e) =>
         {
             eventRaised = true;
             receivedScale = e.Scale;
@@ -393,7 +393,7 @@ public class TouchInputSimulatorTests
         var border = CreateBorderWithWindow();
         var eventRaised = false;
 
-        border.AddHandler(Gestures.PinchEndedEvent, (object? s, PinchEndedEventArgs e) =>
+        border.AddHandler(InputElement.PinchEndedEvent, (object? s, PinchEndedEventArgs e) =>
         {
             eventRaised = true;
         });
@@ -414,7 +414,7 @@ public class TouchInputSimulatorTests
         var eventRaised = false;
         Vector? receivedDelta = null;
 
-        border.AddHandler(Gestures.ScrollGestureEvent, (object? s, ScrollGestureEventArgs e) =>
+        border.AddHandler(InputElement.ScrollGestureEvent, (object? s, ScrollGestureEventArgs e) =>
         {
             eventRaised = true;
             receivedDelta = e.Delta;
@@ -436,7 +436,7 @@ public class TouchInputSimulatorTests
         var border = CreateBorderWithWindow();
         var eventRaised = false;
 
-        border.AddHandler(Gestures.ScrollGestureEndedEvent, (object? s, ScrollGestureEndedEventArgs e) =>
+        border.AddHandler(InputElement.ScrollGestureEndedEvent, (object? s, ScrollGestureEndedEventArgs e) =>
         {
             eventRaised = true;
         });
@@ -457,7 +457,7 @@ public class TouchInputSimulatorTests
         var eventRaised = false;
         Vector? receivedDelta = null;
 
-        border.AddHandler(Gestures.PointerTouchPadGestureMagnifyEvent, (object? s, PointerDeltaEventArgs e) =>
+        border.AddHandler(InputElement.PointerTouchPadGestureMagnifyEvent, (object? s, PointerDeltaEventArgs e) =>
         {
             eventRaised = true;
             receivedDelta = e.Delta;
@@ -480,7 +480,7 @@ public class TouchInputSimulatorTests
         var eventRaised = false;
         Vector? receivedDelta = null;
 
-        border.AddHandler(Gestures.PointerTouchPadGestureSwipeEvent, (object? s, PointerDeltaEventArgs e) =>
+        border.AddHandler(InputElement.PointerTouchPadGestureSwipeEvent, (object? s, PointerDeltaEventArgs e) =>
         {
             eventRaised = true;
             receivedDelta = e.Delta;
@@ -502,7 +502,7 @@ public class TouchInputSimulatorTests
         var border = CreateBorderWithWindow();
         var eventRaised = false;
 
-        border.AddHandler(Gestures.PointerTouchPadGestureRotateEvent, (object? s, PointerDeltaEventArgs e) =>
+        border.AddHandler(InputElement.PointerTouchPadGestureRotateEvent, (object? s, PointerDeltaEventArgs e) =>
         {
             eventRaised = true;
         });
@@ -549,8 +549,8 @@ public class TouchInputSimulatorTests
         var pinchCount = 0;
         var pinchEndedRaised = false;
 
-        border.AddHandler(Gestures.PinchEvent, (object? s, PinchEventArgs e) => pinchCount++);
-        border.AddHandler(Gestures.PinchEndedEvent, (object? s, PinchEndedEventArgs e) => pinchEndedRaised = true);
+        border.AddHandler(InputElement.PinchEvent, (object? s, PinchEventArgs e) => pinchCount++);
+        border.AddHandler(InputElement.PinchEndedEvent, (object? s, PinchEndedEventArgs e) => pinchEndedRaised = true);
 
         // Act
         simulator.SimulatePinchZoom(border, new Point(200, 150), startDistance: 50, endDistance: 150, steps: 5);
@@ -569,8 +569,8 @@ public class TouchInputSimulatorTests
         var scrollCount = 0;
         var scrollEndedRaised = false;
 
-        border.AddHandler(Gestures.ScrollGestureEvent, (object? s, ScrollGestureEventArgs e) => scrollCount++);
-        border.AddHandler(Gestures.ScrollGestureEndedEvent, (object? s, ScrollGestureEndedEventArgs e) => scrollEndedRaised = true);
+        border.AddHandler(InputElement.ScrollGestureEvent, (object? s, ScrollGestureEventArgs e) => scrollCount++);
+        border.AddHandler(InputElement.ScrollGestureEndedEvent, (object? s, ScrollGestureEndedEventArgs e) => scrollEndedRaised = true);
 
         // Act
         simulator.SimulateTwoFingerPan(border, new Point(100, 100), new Point(200, 150), steps: 5);
@@ -589,7 +589,7 @@ public class TouchInputSimulatorTests
         var pinchCount = 0;
         var hasAngleDelta = false;
 
-        border.AddHandler(Gestures.PinchEvent, (object? s, PinchEventArgs e) =>
+        border.AddHandler(InputElement.PinchEvent, (object? s, PinchEventArgs e) =>
         {
             pinchCount++;
             if (Math.Abs(e.AngleDelta) > 0.001)
@@ -638,7 +638,7 @@ public class TouchInputSimulatorTests
         border.PointerMoved += (s, e) => lastPosition = e.GetPosition(border);
 
         // Act
-        simulator.Swipe(border, new Point(200, 100), SwipeDirection.Left, distance: 100);
+        simulator.Swipe(border, new Point(200, 100), Avalonia.HeadlessTestingFramework.SwipeDirection.Left, distance: 100);
 
         // Assert
         Assert.NotNull(lastPosition);
@@ -656,7 +656,7 @@ public class TouchInputSimulatorTests
         border.PointerMoved += (s, e) => lastPosition = e.GetPosition(border);
 
         // Act
-        simulator.Swipe(border, new Point(100, 100), SwipeDirection.Right, distance: 100);
+        simulator.Swipe(border, new Point(100, 100), Avalonia.HeadlessTestingFramework.SwipeDirection.Right, distance: 100);
 
         // Assert
         Assert.NotNull(lastPosition);
@@ -674,7 +674,7 @@ public class TouchInputSimulatorTests
         border.PointerMoved += (s, e) => lastPosition = e.GetPosition(border);
 
         // Act
-        simulator.Swipe(border, new Point(100, 200), SwipeDirection.Up, distance: 100);
+        simulator.Swipe(border, new Point(100, 200), Avalonia.HeadlessTestingFramework.SwipeDirection.Up, distance: 100);
 
         // Assert
         Assert.NotNull(lastPosition);
@@ -692,7 +692,7 @@ public class TouchInputSimulatorTests
         border.PointerMoved += (s, e) => lastPosition = e.GetPosition(border);
 
         // Act
-        simulator.Swipe(border, new Point(100, 100), SwipeDirection.Down, distance: 100);
+        simulator.Swipe(border, new Point(100, 100), Avalonia.HeadlessTestingFramework.SwipeDirection.Down, distance: 100);
 
         // Assert
         Assert.NotNull(lastPosition);


### PR DESCRIPTION
# PR Summary: Upgrade PanAndZoom to Avalonia 12.0.0

## Branch

`chore/avalonia-12-rc1-upgrade`

## Commit Highlights

- `7a5a1d0` `build: upgrade repo to Avalonia 12 rc1`
- `247dca1` `refactor: update PanAndZoom for Avalonia 12 input APIs`
- `ed9a9d3` `refactor: migrate headless helpers to Avalonia 12`
- `ead7ff4` `test: update gesture tests for Avalonia 12`
- `70e96f8` `fix: address Avalonia 12 review follow-ups`
- `020a7c9` `Merge remote-tracking branch 'origin/master' into chore/avalonia-12-rc1-upgrade`
- `cf7a1d0` `build: upgrade Avalonia packages to 12.0.0`
- `34b7e33` `docs: update Avalonia 12 installation versions`
- `be1d381` `chore: replace obsolete TextBox watermark usage`

## Overview

This PR upgrades the repository from Avalonia `11.3.9` to stable `12.0.0`, keeps the earlier Avalonia 12 migration work intact, and syncs the branch with the latest `master`.

The branch updates package and test infrastructure, adapts the control and headless testing helpers to the Avalonia 12 input and gesture APIs, finalizes the package line on the stable release, and refreshes the sample and docs cleanup that was still tied to the RC migration.

## What Changed

### 1. Avalonia 12 migration

- Updated the control and headless testing framework for Avalonia 12 input and gesture APIs.
- Moved gesture event usage from `Gestures.*` to `InputElement.*`.
- Updated Avalonia 12 compatibility fixes around root lookup, holding gesture handling, and touch helpers.
- Kept the two libraries on `net8.0;net10.0`.
- Migrated the test line to xUnit v3.

### 2. Stable 12.0.0 finalization

- Updated shared package pins from `12.0.0-rc1` to `12.0.0` for `Avalonia`, `Avalonia.Desktop`, `Avalonia.Headless`, `Avalonia.Headless.XUnit`, `Avalonia.Skia`, `Avalonia.Themes.Fluent`, `Avalonia.Fonts.Inter`, and `Avalonia.Browser`.
- Removed `VersionSuffix = rc1` so repo package versions now resolve to `12.0.0`.
- Updated installation docs to reference stable `12.0.0`.
- Restored `build/Avalonia.Diagnostics.props` and switched the diagnostics package to `ProDiagnostics` `12.0.0` instead of `AvaloniaUI.DiagnosticsSupport`.
- Re-enabled the shared diagnostics props import in the sample projects so the sample project layout stays aligned with the repo solution.

### 3. Sample and test cleanup

- Replaced obsolete `TextBox.Watermark` usage with `PlaceholderText` in sample XAML and affected tests.
- Kept the sample compiled-binding opt-out scoped to the sample project only so this PR stays focused on the framework migration instead of a broader XAML typing pass.

### 4. Branch sync

- Merged the latest `master` into the upgrade branch before finalizing the stable package update so the PR reflects the current branch tip rather than a stale RC snapshot.

## Validation

The following commands were run successfully:

```bash
dotnet build PanAndZoom.slnx
dotnet test PanAndZoom.slnx --no-build
```

Observed results:

- `HeadlessTestingFramework.UnitTests`: `113 passed`, `0 failed`
- `Avalonia.Controls.PanAndZoom.UnitTests`: `1197 passed`, `1 skipped`, `0 failed`
- Solution build: passed

## Remaining Warnings

- xUnit v3 transitive version mismatch warnings (`NU1608`) in the test projects.
- `Tmds.DBus.Protocol 0.90.3` vulnerability warning (`NU1903`) from a transitive dependency in the sample desktop app.
- Existing analyzer and XML-doc warnings in the headless framework and tests.
