### PR TITLE
Touch gestures: applied incremental zoom and converted pinch origin to child coordinates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,7 +102,10 @@ jobs:
 
       - name: Publish test results
         uses: dorny/test-reporter@v1
-        if: always()
+        if: >
+          always() &&
+          (github.event_name != 'pull_request' ||
+           github.event.pull_request.head.repo.full_name == github.repository)
         with:
           name: Test Results (${{ matrix.os }})
           path: artifacts/test/**/*.trx

--- a/src/PanAndZoom/ZoomBorder.cs
+++ b/src/PanAndZoom/ZoomBorder.cs
@@ -79,7 +79,11 @@ public partial class ZoomBorder : Border
     private DateTime _gestureStartTime;
     private bool _gestureRecognized;
     private bool _simultaneousGestureActive;
-    
+
+    // Pinch tracking
+    private bool _pinchActive;
+    private double _lastPinchScale = 1.0;
+
     // Zoom indicator
     private DispatcherTimer? _zoomIndicatorTimer;
     private bool _zoomIndicatorVisible;
@@ -279,7 +283,7 @@ public partial class ZoomBorder : Border
         {
             return;
         }
-        
+
         // Check gesture recognition delay
         if (!_gestureRecognized)
         {
@@ -287,15 +291,15 @@ public partial class ZoomBorder : Border
             {
                 _gestureStartTime = DateTime.Now;
             }
-            
+
             if ((DateTime.Now - _gestureStartTime) < GestureRecognitionDelay)
             {
                 return;
             }
-            
+
             _gestureRecognized = true;
         }
-        
+
         // Check if simultaneous pan/zoom is allowed
         if (!EnableSimultaneousPanZoom && _isPanning)
         {
@@ -303,14 +307,17 @@ public partial class ZoomBorder : Border
         }
 
         Log($"[PinchGesture] {Name} Scale: {e.Scale}, AngleDelta: {e.AngleDelta}");
-        
-        // ScaleOrigin is already in element pixel coordinates (midpoint of two touch points)
-        // from Avalonia's PinchGestureRecognizer, so use it directly
-        var elementPoint = e.ScaleOrigin;
-        
+
+        // Start from the reported pinch origin
+        var visualPoint = e.ScaleOrigin;
+
+        // Convert the pinch origin from ZoomBorder coordinates into child coordinates.
+        var translatedPoint = this.TranslatePoint(visualPoint, _element);
+        var zoomCenter = translatedPoint ?? visualPoint;
+
         // Mark simultaneous gesture as active
         _simultaneousGestureActive = EnableSimultaneousPanZoom && _isPanning;
-        
+
         // Raise GestureStarted event
         var previousMatrix = _matrix;
         var gestureArgs = new GestureEventArgs(
@@ -319,30 +326,43 @@ public partial class ZoomBorder : Border
             _zoomY,
             _offsetX,
             _offsetY,
-            elementPoint.X,
-            elementPoint.Y,
+            zoomCenter.X,
+            zoomCenter.Y,
             e.Scale - 1.0,
             _matrix,
             previousMatrix
         );
         RaiseGestureStarted(gestureArgs);
-        
+
         // Apply zoom if enabled
         if (EnableGestureZoom)
         {
-            // Use ZoomTo with the scale factor directly
-            // e.Scale is a multiplicative factor (e.g., 1.2 for 20% zoom in)
-            ZoomTo(e.Scale, elementPoint.X, elementPoint.Y);
+            if (!_pinchActive)
+            {
+                _pinchActive = true;
+                _lastPinchScale = 1.0;
+            }
+
+            // Avalonia pinch scale is cumulative since gesture start,
+            // so convert it to an incremental factor.
+            var deltaScale = e.Scale / _lastPinchScale;
+            _lastPinchScale = e.Scale;
+
+            if (!double.IsNaN(deltaScale) && !double.IsInfinity(deltaScale) && deltaScale > 0.0)
+            {
+                Log($"[ZoomTo] factor: {deltaScale}, center: {zoomCenter.X}, {zoomCenter.Y}");
+                ZoomTo(deltaScale, zoomCenter.X, zoomCenter.Y);
+            }
         }
-        
+
         // Apply rotation if enabled
         if (EnableGestureRotation && Math.Abs(e.AngleDelta) > 0.001)
         {
             // AngleDelta is in degrees (positive = clockwise, negative = counterclockwise)
             // Use RotateAt to rotate around the pinch center point
-            RotateAt(e.AngleDelta, elementPoint, animate: false);
+            RotateAt(e.AngleDelta, zoomCenter, animate: false);
         }
-        
+
         e.Handled = true;
     }
 
@@ -350,15 +370,18 @@ public partial class ZoomBorder : Border
     {
         if (!EnableGestures)
             return;
-            
+
         Log($"[PinchGestureEnded] {Name}");
-        
+
         // Reset gesture tracking state
         _gestureRecognized = false;
         _gestureStartTime = default;
         _simultaneousGestureActive = false;
-        
+
         // Raise GestureEnded event
+        _pinchActive = false;
+        _lastPinchScale = 1.0;
+
         var gestureArgs = new GestureEventArgs(
             "Pinch",
             _zoomX,
@@ -375,7 +398,7 @@ public partial class ZoomBorder : Border
         
         // Add to view history after pinch gesture completes
         AddToViewHistory();
-        
+
         e.Handled = true;
     }
 
@@ -389,7 +412,7 @@ public partial class ZoomBorder : Border
         {
             return;
         }
-        
+
         // Check if simultaneous pan/zoom is allowed when another gesture is active
         if (!EnableSimultaneousPanZoom && _simultaneousGestureActive)
         {
@@ -397,7 +420,7 @@ public partial class ZoomBorder : Border
         }
 
         Log($"[ScrollGesture] {Name} Delta: {e.Delta}");
-        
+
         // Raise GestureStarted event
         var previousMatrix = _matrix;
         var gestureArgs = new GestureEventArgs(
@@ -413,20 +436,20 @@ public partial class ZoomBorder : Border
             previousMatrix
         );
         RaiseGestureStarted(gestureArgs);
-        
+
         // Use the scroll delta for panning. Scroll gesture delta follows
         // scroll direction semantics (positive = scroll down/right), which is
         // opposite to direct manipulation (content following finger). Invert
         // it so the content moves with the finger on touch/gesture devices.
         PanDelta(-e.Delta.X, -e.Delta.Y);
-        
+
         e.Handled = true;
     }
 
     private void Border_ScrollGestureEnded(object? sender, ScrollGestureEndedEventArgs e)
     {
         Log($"[ScrollGestureEnded] {Name}");
-        
+
         // Raise GestureEnded event
         var gestureArgs = new GestureEventArgs(
             "Scroll",
@@ -444,7 +467,7 @@ public partial class ZoomBorder : Border
         
         // Add to view history after scroll gesture completes
         AddToViewHistory();
-        
+
         e.Handled = true;
     }
 
@@ -2337,7 +2360,7 @@ public partial class ZoomBorder : Border
 
         _updating = true;
 
-        Log("[ZoomTo]");
+        Log($"[ZoomTo] factor: {ratio}, center: {x}, {y}");
         var previousMatrix = _matrix;
         var previousZoomX = _zoomX;
         var previousZoomY = _zoomY;

--- a/src/PanAndZoom/ZoomBorder.cs
+++ b/src/PanAndZoom/ZoomBorder.cs
@@ -252,6 +252,7 @@ public partial class ZoomBorder : Border
     private void PanAndZoom_DetachedFromVisualTree(object? sender, VisualTreeAttachmentEventArgs e)
     {
         Log($"[DetachedFromVisualTree] {Name}");
+        ResetPinchGestureState();
         DetachElement();
         
         // Remove pointer event handlers

--- a/src/PanAndZoom/ZoomBorder.cs
+++ b/src/PanAndZoom/ZoomBorder.cs
@@ -152,6 +152,8 @@ public partial class ZoomBorder : Border
         }
         else if (!EnableGestures && _gestureRecognizersAdded)
         {
+            ResetPinchGestureState();
+
             // Since GestureRecognizerCollection doesn't support Remove/Clear,
             // we need to recreate the recognizers to effectively "remove" them
             _pinchGestureRecognizer = new PinchGestureRecognizer();
@@ -163,6 +165,15 @@ public partial class ZoomBorder : Border
             
             _gestureRecognizersAdded = false;
         }
+    }
+
+    private void ResetPinchGestureState()
+    {
+        _gestureRecognized = false;
+        _gestureStartTime = default;
+        _simultaneousGestureActive = false;
+        _pinchActive = false;
+        _lastPinchScale = 1.0;
     }
 
     /// <summary>
@@ -368,19 +379,12 @@ public partial class ZoomBorder : Border
 
     private void Border_PinchGestureEnded(object? sender, PinchEndedEventArgs e)
     {
+        ResetPinchGestureState();
+
         if (!EnableGestures)
             return;
 
         Log($"[PinchGestureEnded] {Name}");
-
-        // Reset gesture tracking state
-        _gestureRecognized = false;
-        _gestureStartTime = default;
-        _simultaneousGestureActive = false;
-
-        // Raise GestureEnded event
-        _pinchActive = false;
-        _lastPinchScale = 1.0;
 
         var gestureArgs = new GestureEventArgs(
             "Pinch",

--- a/tests/Avalonia.Controls.PanAndZoom.UnitTests/ZoomBorderGestureToggleTests.cs
+++ b/tests/Avalonia.Controls.PanAndZoom.UnitTests/ZoomBorderGestureToggleTests.cs
@@ -50,6 +50,63 @@ public class ZoomBorderGestureToggleTests
         // Assert
         Assert.False(zoomBorder.EnableGestures, "EnableGestures should be false");
     }
+
+    [AvaloniaFact]
+    public void EnableGestures_ToggledOffMidPinch_NextPinchStartsFresh()
+    {
+        // Arrange
+        var zoomBorder = new ZoomBorder
+        {
+            Width = 400,
+            Height = 300,
+            EnableGestures = true,
+            EnableGestureZoom = true
+        };
+
+        var childElement = new Border
+        {
+            Width = 200,
+            Height = 150,
+            Background = Brushes.Red
+        };
+
+        zoomBorder.Child = childElement;
+
+        var window = new Window { Content = zoomBorder };
+        window.Show();
+
+        var firstPinchEventArgs = new PinchEventArgs(2.0, new Point(200, 150), 0.0, 0.0)
+        {
+            RoutedEvent = InputElement.PinchEvent,
+            Source = zoomBorder
+        };
+
+        zoomBorder.RaiseEvent(firstPinchEventArgs);
+        var zoomAfterFirstPinch = zoomBorder.ZoomX;
+
+        zoomBorder.EnableGestures = false;
+
+        var pinchEndedEventArgs = new PinchEndedEventArgs
+        {
+            RoutedEvent = InputElement.PinchEndedEvent,
+            Source = zoomBorder
+        };
+
+        zoomBorder.RaiseEvent(pinchEndedEventArgs);
+        zoomBorder.EnableGestures = true;
+
+        var secondPinchEventArgs = new PinchEventArgs(1.5, new Point(200, 150), 0.0, 0.0)
+        {
+            RoutedEvent = InputElement.PinchEvent,
+            Source = zoomBorder
+        };
+
+        zoomBorder.RaiseEvent(secondPinchEventArgs);
+
+        // Assert
+        Assert.True(zoomBorder.ZoomX > zoomAfterFirstPinch,
+            $"A fresh pinch should continue zooming in after gestures are re-enabled. Previous: {zoomAfterFirstPinch}, Current: {zoomBorder.ZoomX}");
+    }
     
     [AvaloniaFact]
     public void EnableGestureZoom_False_PinchGestureIgnored()

--- a/tests/Avalonia.Controls.PanAndZoom.UnitTests/ZoomBorderTouchGestureComprehensiveTests.cs
+++ b/tests/Avalonia.Controls.PanAndZoom.UnitTests/ZoomBorderTouchGestureComprehensiveTests.cs
@@ -105,13 +105,15 @@ public class ZoomBorderTouchGestureComprehensiveTests
         var zoomBorder = CreateZoomBorder();
         ShowInWindow(zoomBorder);
         var simulator = new TouchInputSimulator();
+        var pinchCenter = new Point(200, 150);
         
         var zoomHistory = new List<double> { zoomBorder.ZoomX };
 
         // Act - Multiple zoom in gestures
         for (int i = 0; i < 5; i++)
         {
-            simulator.PinchGesture(zoomBorder, 1.2, new Point(0.5, 0.5));
+            simulator.PinchGesture(zoomBorder, 1.2, pinchCenter);
+            simulator.PinchGestureEnded(zoomBorder);
             zoomHistory.Add(zoomBorder.ZoomX);
         }
 
@@ -130,19 +132,24 @@ public class ZoomBorderTouchGestureComprehensiveTests
         var zoomBorder = CreateZoomBorder();
         ShowInWindow(zoomBorder);
         var simulator = new TouchInputSimulator();
+        var topLeft = new Point(50, 50);
+        var center = new Point(200, 150);
+        var bottomRight = new Point(350, 250);
         
         // First zoom at top-left
-        simulator.PinchGesture(zoomBorder, 1.5, new Point(0.0, 0.0));
+        simulator.PinchGesture(zoomBorder, 1.5, topLeft);
         var offsetAfterTopLeft = (zoomBorder.OffsetX, zoomBorder.OffsetY);
+        simulator.PinchGestureEnded(zoomBorder);
         zoomBorder.ResetMatrix();
         
         // Then zoom at center
-        simulator.PinchGesture(zoomBorder, 1.5, new Point(0.5, 0.5));
+        simulator.PinchGesture(zoomBorder, 1.5, center);
         var offsetAfterCenter = (zoomBorder.OffsetX, zoomBorder.OffsetY);
+        simulator.PinchGestureEnded(zoomBorder);
         zoomBorder.ResetMatrix();
         
         // Then zoom at bottom-right
-        simulator.PinchGesture(zoomBorder, 1.5, new Point(1.0, 1.0));
+        simulator.PinchGesture(zoomBorder, 1.5, bottomRight);
         var offsetAfterBottomRight = (zoomBorder.OffsetX, zoomBorder.OffsetY);
 
         // Assert - Different origins should produce different offsets

--- a/tests/Avalonia.Controls.PanAndZoom.UnitTests/ZoomBorderVisualTreeLifecycleTests.cs
+++ b/tests/Avalonia.Controls.PanAndZoom.UnitTests/ZoomBorderVisualTreeLifecycleTests.cs
@@ -279,6 +279,57 @@ public class ZoomBorderVisualTreeLifecycleTests
         // Gesture should not work when disabled
         Assert.Equal(initialZoom, zoomBorder.ZoomX);
     }
+
+    [AvaloniaFact]
+    public void DetachDuringPinch_ReattachStartsFreshPinchState()
+    {
+        // Arrange
+        var zoomBorder = new ZoomBorder
+        {
+            Width = 400,
+            Height = 300,
+            EnableGestures = true,
+            EnableGestureZoom = true
+        };
+
+        var childElement = new Border
+        {
+            Width = 200,
+            Height = 150,
+            Background = Brushes.Red
+        };
+
+        zoomBorder.Child = childElement;
+
+        var window = new Window { Content = zoomBorder };
+        window.Show();
+
+        var firstPinchEventArgs = new PinchEventArgs(2.0, new Point(200, 150), 0.0, 0.0)
+        {
+            RoutedEvent = InputElement.PinchEvent,
+            Source = zoomBorder
+        };
+
+        zoomBorder.RaiseEvent(firstPinchEventArgs);
+        var zoomAfterFirstPinch = zoomBorder.ZoomX;
+
+        // Detach mid-pinch before PinchEnded can reset state.
+        window.Content = null;
+        window.Content = zoomBorder;
+
+        var secondPinchEventArgs = new PinchEventArgs(1.5, new Point(200, 150), 0.0, 0.0)
+        {
+            RoutedEvent = InputElement.PinchEvent,
+            Source = zoomBorder
+        };
+
+        // Act
+        zoomBorder.RaiseEvent(secondPinchEventArgs);
+
+        // Assert
+        Assert.True(zoomBorder.ZoomX > zoomAfterFirstPinch,
+            $"A fresh pinch after reattach should continue zooming in. Previous: {zoomAfterFirstPinch}, Current: {zoomBorder.ZoomX}");
+    }
     
     [AvaloniaFact]
     public void EventHandlerLifecycle_NoMemoryLeaks()


### PR DESCRIPTION
I've introduced these changes to have a consistent behavior using touch gestures for zooming and rotating in android and iOS devices. I believe #120 wasn't correctly solved.