### PR TITLE
Fix stretch handling during resize

### DIFF
--- a/src/PanAndZoom/ZoomBorder.cs
+++ b/src/PanAndZoom/ZoomBorder.cs
@@ -83,6 +83,7 @@ public partial class ZoomBorder : Border
     // Pinch tracking
     private bool _pinchActive;
     private double _lastPinchScale = 1.0;
+    private bool _autoFitPending = true;
 
     // Zoom indicator
     private DispatcherTimer? _zoomIndicatorTimer;
@@ -127,6 +128,7 @@ public partial class ZoomBorder : Border
         
         // Subscribe to EnableGestures property changes
         this.GetObservable(EnableGesturesProperty).Subscribe(new AnonymousObserver<bool>(_ => UpdateGestureRecognizers()));
+        this.GetObservable(StretchProperty).Subscribe(new AnonymousObserver<StretchMode>(_ => _autoFitPending = true));
     }
 
     /// <summary>
@@ -210,7 +212,11 @@ public partial class ZoomBorder : Border
             return size;
         }
 
-        AutoFit(size.Width, size.Height, _element.Bounds.Width, _element.Bounds.Height);
+        if (_autoFitPending)
+        {
+            AutoFit(size.Width, size.Height, _element.Bounds.Width, _element.Bounds.Height);
+            _autoFitPending = false;
+        }
 
         return size;
     }
@@ -820,6 +826,7 @@ public partial class ZoomBorder : Border
 
         _element = element;
         _element.PropertyChanged += Element_PropertyChanged;
+        _autoFitPending = true;
         
         // Notify commands that element is now available
         RaiseCommandsCanExecuteChanged();
@@ -835,6 +842,7 @@ public partial class ZoomBorder : Border
         _element.PropertyChanged -= Element_PropertyChanged;
         _element.RenderTransform = null;
         _element = null;
+        _autoFitPending = true;
         
         // Notify commands that element is no longer available
         RaiseCommandsCanExecuteChanged();

--- a/tests/Avalonia.Controls.PanAndZoom.UnitTests/ZoomBorderResizeBehaviorTests.cs
+++ b/tests/Avalonia.Controls.PanAndZoom.UnitTests/ZoomBorderResizeBehaviorTests.cs
@@ -134,6 +134,72 @@ public class ZoomBorderResizeBehaviorTests
         Assert.Equal(initialOffsetY, zoomBorder.OffsetY);
     }
 
+    [AvaloniaTheory]
+    [InlineData(ResizeBehaviorMode.None)]
+    [InlineData(ResizeBehaviorMode.MaintainCenter)]
+    [InlineData(ResizeBehaviorMode.MaintainTopLeft)]
+    [InlineData(ResizeBehaviorMode.MaintainZoom)]
+    [InlineData(ResizeBehaviorMode.Custom)]
+    public void ResizeBehavior_DoesNotReapplyStretchUnlessRequested(ResizeBehaviorMode resizeBehavior)
+    {
+        var zoomBorder = new ZoomBorder
+        {
+            Width = 400,
+            Height = 300,
+            ResizeBehavior = resizeBehavior,
+            Stretch = StretchMode.Uniform,
+            Child = new Border
+            {
+                Width = 200,
+                Height = 150,
+                Background = Brushes.Red
+            }
+        };
+        var window = new Window { Content = zoomBorder };
+        window.Show();
+        window.UpdateLayout();
+
+        zoomBorder.ZoomTo(1.25, 100, 75, skipTransitions: true);
+        var zoomBeforeResize = zoomBorder.ZoomX;
+
+        zoomBorder.Width = 600;
+        zoomBorder.Height = 450;
+        window.UpdateLayout();
+
+        Assert.Equal(2.5, zoomBeforeResize, 5);
+        Assert.Equal(zoomBeforeResize, zoomBorder.ZoomX, 5);
+        Assert.Equal(zoomBeforeResize, zoomBorder.ZoomY, 5);
+    }
+
+    [AvaloniaFact]
+    public void ChangingStretch_ReappliesTheNewStretchMode()
+    {
+        var zoomBorder = new ZoomBorder
+        {
+            Width = 400,
+            Height = 300,
+            ResizeBehavior = ResizeBehaviorMode.None,
+            Stretch = StretchMode.Uniform,
+            Child = new Border
+            {
+                Width = 200,
+                Height = 100,
+                Background = Brushes.Red
+            }
+        };
+        var window = new Window { Content = zoomBorder };
+        window.Show();
+        window.UpdateLayout();
+
+        Assert.Equal(2.0, zoomBorder.ZoomX, 5);
+
+        zoomBorder.Stretch = StretchMode.UniformToFill;
+        window.UpdateLayout();
+
+        Assert.Equal(3.0, zoomBorder.ZoomX, 5);
+        Assert.Equal(3.0, zoomBorder.ZoomY, 5);
+    }
+
     [AvaloniaFact]
     public void ResizeBehavior_MaintainZoom_PreservesZoomLevelOnResize()
     {


### PR DESCRIPTION
## What changed

- Apply `Stretch` only for the initial child layout or when `Stretch` itself changes.
- Let `ResizeBehavior` exclusively determine what happens on subsequent viewport resizes.
- Add regression coverage for every non-refit resize mode and dynamic stretch changes.

## Why

`ArrangeOverride` previously called `AutoFit` on every arrange. That reset the transform after the resize handler ran, so modes such as `MaintainCenter`, `MaintainZoom`, and `None` only appeared to work when `Stretch=None`.

## Validation

- `dotnet test PanAndZoom.slnx --no-restore`

Fixes #130
