### PR TITLE
Fix built-in pan and zoom animations

### DIFF
--- a/src/PanAndZoom/ZoomBorder.Properties.cs
+++ b/src/PanAndZoom/ZoomBorder.Properties.cs
@@ -1362,37 +1362,37 @@ public partial class ZoomBorder
     /// <summary>
     /// Gets the command to zoom in.
     /// </summary>
-    public ICommand ZoomInCommand => _zoomInCommand ??= new ZoomBorderCommand(() => ZoomIn(ShouldAnimate()), () => EnableZoom && _element != null);
+    public ICommand ZoomInCommand => _zoomInCommand ??= new ZoomBorderCommand(() => ZoomIn(ShouldSkipTransitions()), () => EnableZoom && _element != null);
 
     /// <summary>
     /// Gets the command to zoom out.
     /// </summary>
-    public ICommand ZoomOutCommand => _zoomOutCommand ??= new ZoomBorderCommand(() => ZoomOut(ShouldAnimate()), () => EnableZoom && _element != null);
+    public ICommand ZoomOutCommand => _zoomOutCommand ??= new ZoomBorderCommand(() => ZoomOut(ShouldSkipTransitions()), () => EnableZoom && _element != null);
 
     /// <summary>
     /// Gets the command to reset the view.
     /// </summary>
-    public ICommand ResetCommand => _resetCommand ??= new ZoomBorderCommand(() => ResetMatrix(ShouldAnimate()));
+    public ICommand ResetCommand => _resetCommand ??= new ZoomBorderCommand(() => ResetMatrix(ShouldSkipTransitions()));
 
     /// <summary>
     /// Gets the command to fit content to viewport.
     /// </summary>
-    public ICommand FitCommand => _fitCommand ??= new ZoomBorderCommand(() => AutoFit(ShouldAnimate()), () => _element != null);
+    public ICommand FitCommand => _fitCommand ??= new ZoomBorderCommand(() => AutoFit(ShouldSkipTransitions()), () => _element != null);
 
     /// <summary>
     /// Gets the command to fill viewport.
     /// </summary>
-    public ICommand FillCommand => _fillCommand ??= new ZoomBorderCommand(() => Fill(ShouldAnimate()), () => _element != null);
+    public ICommand FillCommand => _fillCommand ??= new ZoomBorderCommand(() => Fill(ShouldSkipTransitions()), () => _element != null);
 
     /// <summary>
     /// Gets the command to apply uniform stretch.
     /// </summary>
-    public ICommand UniformCommand => _uniformCommand ??= new ZoomBorderCommand(() => Uniform(ShouldAnimate()), () => _element != null);
+    public ICommand UniformCommand => _uniformCommand ??= new ZoomBorderCommand(() => Uniform(ShouldSkipTransitions()), () => _element != null);
 
     /// <summary>
     /// Gets the command to apply uniform to fill stretch.
     /// </summary>
-    public ICommand UniformToFillCommand => _uniformToFillCommand ??= new ZoomBorderCommand(() => UniformToFill(ShouldAnimate()), () => _element != null);
+    public ICommand UniformToFillCommand => _uniformToFillCommand ??= new ZoomBorderCommand(() => UniformToFill(ShouldSkipTransitions()), () => _element != null);
 
     /// <summary>
     /// Gets the command to navigate back in view history.

--- a/src/PanAndZoom/ZoomBorder.cs
+++ b/src/PanAndZoom/ZoomBorder.cs
@@ -84,6 +84,7 @@ public partial class ZoomBorder : Border
     private bool _pinchActive;
     private double _lastPinchScale = 1.0;
     private bool _autoFitPending = true;
+    private Animation.TransformOperationsTransition? _animationTransition;
 
     // Zoom indicator
     private DispatcherTimer? _zoomIndicatorTimer;
@@ -129,6 +130,8 @@ public partial class ZoomBorder : Border
         // Subscribe to EnableGestures property changes
         this.GetObservable(EnableGesturesProperty).Subscribe(new AnonymousObserver<bool>(_ => UpdateGestureRecognizers()));
         this.GetObservable(StretchProperty).Subscribe(new AnonymousObserver<StretchMode>(_ => _autoFitPending = true));
+        this.GetObservable(EnableAnimationsProperty).Subscribe(new AnonymousObserver<bool>(_ => UpdateAnimationTransition()));
+        this.GetObservable(AnimationDurationProperty).Subscribe(new AnonymousObserver<TimeSpan>(_ => UpdateAnimationTransition()));
     }
 
     /// <summary>
@@ -549,11 +552,11 @@ public partial class ZoomBorder : Border
         switch (DoubleClickZoomMode)
         {
             case DoubleClickZoomMode.ZoomIn:
-                ZoomTo(DoubleClickZoomFactor, point.X, point.Y, ShouldAnimate());
+                ZoomTo(DoubleClickZoomFactor, point.X, point.Y, ShouldSkipTransitions());
                 break;
 
             case DoubleClickZoomMode.ZoomOut:
-                ZoomTo(1.0 / DoubleClickZoomFactor, point.X, point.Y, ShouldAnimate());
+                ZoomTo(1.0 / DoubleClickZoomFactor, point.X, point.Y, ShouldSkipTransitions());
                 break;
 
             case DoubleClickZoomMode.ZoomInOut:
@@ -561,17 +564,17 @@ public partial class ZoomBorder : Border
                 if (_zoomX >= _doubleClickZoomThreshold)
                 {
                     // Zoom out or reset
-                    ResetMatrix(ShouldAnimate());
+                    ResetMatrix(ShouldSkipTransitions());
                 }
                 else
                 {
                     // Zoom in
-                    ZoomTo(DoubleClickZoomFactor, point.X, point.Y, ShouldAnimate());
+                    ZoomTo(DoubleClickZoomFactor, point.X, point.Y, ShouldSkipTransitions());
                 }
                 break;
 
             case DoubleClickZoomMode.ZoomToFit:
-                AutoFit(ShouldAnimate());
+                AutoFit(ShouldSkipTransitions());
                 break;
 
             case DoubleClickZoomMode.None:
@@ -602,7 +605,7 @@ public partial class ZoomBorder : Border
                 else
                 {
                     // Left arrow: Pan left
-                    PanDelta(-KeyboardPanStep, 0, ShouldAnimate());
+                    PanDelta(-KeyboardPanStep, 0, ShouldSkipTransitions());
                 }
                 break;
 
@@ -618,18 +621,18 @@ public partial class ZoomBorder : Border
                 else
                 {
                     // Right arrow: Pan right
-                    PanDelta(KeyboardPanStep, 0, ShouldAnimate());
+                    PanDelta(KeyboardPanStep, 0, ShouldSkipTransitions());
                 }
                 break;
 
             case Key.Up:
                 // Up arrow: Pan up
-                PanDelta(0, -KeyboardPanStep, ShouldAnimate());
+                PanDelta(0, -KeyboardPanStep, ShouldSkipTransitions());
                 break;
 
             case Key.Down:
                 // Down arrow: Pan down
-                PanDelta(0, KeyboardPanStep, ShouldAnimate());
+                PanDelta(0, KeyboardPanStep, ShouldSkipTransitions());
                 break;
 
             case Key.Add:
@@ -639,7 +642,7 @@ public partial class ZoomBorder : Border
                 {
                     var centerX = _element.Bounds.Width / 2.0;
                     var centerY = _element.Bounds.Height / 2.0;
-                    ZoomTo(KeyboardZoomStep, centerX, centerY, ShouldAnimate());
+                    ZoomTo(KeyboardZoomStep, centerX, centerY, ShouldSkipTransitions());
                 }
                 break;
 
@@ -650,7 +653,7 @@ public partial class ZoomBorder : Border
                 {
                     var centerX = _element.Bounds.Width / 2.0;
                     var centerY = _element.Bounds.Height / 2.0;
-                    ZoomTo(1.0 / KeyboardZoomStep, centerX, centerY, ShouldAnimate());
+                    ZoomTo(1.0 / KeyboardZoomStep, centerX, centerY, ShouldSkipTransitions());
                 }
                 break;
 
@@ -658,7 +661,7 @@ public partial class ZoomBorder : Border
                 if (e.KeyModifiers.HasFlag(KeyModifiers.Control))
                 {
                     // Ctrl+0: Reset to 100% zoom (1:1)
-                    ResetMatrix(ShouldAnimate());
+                    ResetMatrix(ShouldSkipTransitions());
                 }
                 else
                 {
@@ -668,7 +671,7 @@ public partial class ZoomBorder : Border
 
             case Key.Home:
                 // Home: Fit to viewport
-                AutoFit(ShouldAnimate());
+                AutoFit(ShouldSkipTransitions());
                 break;
 
             default:
@@ -827,6 +830,7 @@ public partial class ZoomBorder : Border
         _element = element;
         _element.PropertyChanged += Element_PropertyChanged;
         _autoFitPending = true;
+        UpdateAnimationTransition();
         
         // Notify commands that element is now available
         RaiseCommandsCanExecuteChanged();
@@ -839,6 +843,7 @@ public partial class ZoomBorder : Border
             return;
         }
 
+        RemoveAnimationTransition();
         _element.PropertyChanged -= Element_PropertyChanged;
         _element.RenderTransform = null;
         _element = null;
@@ -861,6 +866,53 @@ public partial class ZoomBorder : Border
     private bool ShouldAnimate()
     {
         return EnableAnimations && AnimationDuration > TimeSpan.Zero;
+    }
+
+    private bool ShouldSkipTransitions()
+    {
+        return !ShouldAnimate();
+    }
+
+    private void UpdateAnimationTransition()
+    {
+        if (_element == null)
+        {
+            return;
+        }
+
+        RemoveAnimationTransition();
+
+        if (!ShouldAnimate())
+        {
+            return;
+        }
+
+        var transitions = _element.Transitions;
+        if (transitions?.OfType<Animation.TransformOperationsTransition>()
+                .Any(transition => transition.Property == Visual.RenderTransformProperty) == true)
+        {
+            return;
+        }
+
+        transitions ??= new Animation.Transitions();
+        _element.Transitions = transitions;
+
+        _animationTransition = new Animation.TransformOperationsTransition
+        {
+            Property = Visual.RenderTransformProperty,
+            Duration = AnimationDuration
+        };
+        transitions.Add(_animationTransition);
+    }
+
+    private void RemoveAnimationTransition()
+    {
+        if (_element?.Transitions != null && _animationTransition != null)
+        {
+            _element.Transitions.Remove(_animationTransition);
+        }
+
+        _animationTransition = null;
     }
 
     private void Pressed(PointerPressedEventArgs e)

--- a/tests/Avalonia.Controls.PanAndZoom.UnitTests/ZoomBorderAnimationTests.cs
+++ b/tests/Avalonia.Controls.PanAndZoom.UnitTests/ZoomBorderAnimationTests.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Wiesław Šoltés. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 using System;
+using System.Linq;
+using Avalonia.Animation;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using Xunit;
@@ -252,5 +254,78 @@ public class ZoomBorderAnimationTests
 
         // Assert - Should still apply (zero duration means no animation)
         Assert.True(zoomBorder.ZoomX > initialZoomX);
+    }
+
+    [AvaloniaFact]
+    public void EnableAnimations_AddsRenderTransformTransitionToChild()
+    {
+        var child = new Canvas { Width = 400, Height = 400 };
+        var zoomBorder = new ZoomBorder
+        {
+            Width = 800,
+            Height = 600,
+            EnableAnimations = true,
+            AnimationDuration = TimeSpan.FromMilliseconds(450),
+            Child = child
+        };
+        var window = new Window { Content = zoomBorder };
+        window.Show();
+
+        var transition = Assert.Single(child.Transitions!.OfType<TransformOperationsTransition>());
+        Assert.Equal(Visual.RenderTransformProperty, transition.Property);
+        Assert.Equal(TimeSpan.FromMilliseconds(450), transition.Duration);
+    }
+
+    [AvaloniaFact]
+    public void AnimationSettings_UpdateOwnedRenderTransformTransition()
+    {
+        var child = new Canvas { Width = 400, Height = 400 };
+        var zoomBorder = new ZoomBorder
+        {
+            Width = 800,
+            Height = 600,
+            EnableAnimations = true,
+            Child = child
+        };
+        var window = new Window { Content = zoomBorder };
+        window.Show();
+
+        zoomBorder.AnimationDuration = TimeSpan.FromMilliseconds(750);
+
+        var transition = Assert.Single(child.Transitions!.OfType<TransformOperationsTransition>());
+        Assert.Equal(TimeSpan.FromMilliseconds(750), transition.Duration);
+
+        zoomBorder.EnableAnimations = false;
+
+        Assert.Empty(child.Transitions!.OfType<TransformOperationsTransition>());
+    }
+
+    [AvaloniaFact]
+    public void EnableAnimations_PreservesExistingRenderTransformTransition()
+    {
+        var existingTransition = new TransformOperationsTransition
+        {
+            Property = Visual.RenderTransformProperty,
+            Duration = TimeSpan.FromSeconds(1)
+        };
+        var child = new Canvas
+        {
+            Width = 400,
+            Height = 400,
+            Transitions = new Transitions { existingTransition }
+        };
+        var zoomBorder = new ZoomBorder
+        {
+            Width = 800,
+            Height = 600,
+            EnableAnimations = true,
+            AnimationDuration = TimeSpan.FromMilliseconds(300),
+            Child = child
+        };
+        var window = new Window { Content = zoomBorder };
+        window.Show();
+
+        Assert.Same(existingTransition, Assert.Single(child.Transitions.OfType<TransformOperationsTransition>()));
+        Assert.Equal(TimeSpan.FromSeconds(1), existingTransition.Duration);
     }
 }


### PR DESCRIPTION
## What changed

- Automatically add a `RenderTransform` transition to the child when animations are enabled.
- Keep the transition duration synchronized with `AnimationDuration` and remove the owned transition when animations are disabled.
- Preserve an application-provided render-transform transition instead of replacing it.
- Correct the inverted transition flag used by commands, keyboard navigation, and double-click actions.
- Add functional coverage for transition creation, updates, disablement, and custom transition preservation.

## Why

The demo enabled animations but its content had no transform transition, so pan and zoom changes were immediate. The default command and input paths also passed the animation decision into the `skipTransitions` parameter without inversion.

## Validation

- `dotnet test PanAndZoom.slnx --no-restore`

Fixes #139
