### PR TITLE
Implement custom content bounds

### DIFF
--- a/site/articles/advanced/custom-bounds-resize-and-rotation.md
+++ b/site/articles/advanced/custom-bounds-resize-and-rotation.md
@@ -8,28 +8,46 @@ If the built-in behavior is close but not exact, `ZoomBorder` exposes virtual ho
 
 ## Extensibility Points
 
-- `GetContentBounds()`: return the effective content bounds used for custom constraints
-- `ValidateTransform(Matrix newMatrix)`: veto proposed transforms
+- `GetContentBounds()`: return the effective bounds in child content coordinates; these bounds constrain panning and define scrollbar extent when `BoundsMode="Custom"`
+- `ValidateTransform(Matrix newMatrix)`: accept or veto the final proposed transform
+- `InvalidateContentBounds()`: reapply constraints and refresh scrollbar state after dynamic custom bounds change
 - `OnResized(Size oldSize, Size newSize)`: apply custom resize policy
 
-Example:
+## Large Panning Area With Scrollbars
+
+`Custom` uses a finite content-coordinate rectangle. Returning a rectangle larger than the child creates extra navigable space while keeping scrollbar positions meaningful:
 
 ```csharp
 public class CustomZoomBorder : ZoomBorder
 {
-    protected override Rect GetContentBounds() => base.GetContentBounds();
+    private Rect _navigationBounds = new(-5000, -5000, 10000, 10000);
+
+    protected override Rect GetContentBounds() => _navigationBounds;
 
     protected override bool ValidateTransform(Matrix newMatrix)
     {
-        return base.ValidateTransform(newMatrix);
+        return newMatrix.M11 is >= 0.1 and <= 20;
     }
 
-    protected override void OnResized(Size oldSize, Size newSize)
+    public void SetNavigationBounds(Rect bounds)
     {
-        base.OnResized(oldSize, newSize);
+        _navigationBounds = bounds;
+        InvalidateContentBounds();
     }
 }
 ```
+
+```xml
+<ScrollViewer HorizontalScrollBarVisibility="Auto"
+              VerticalScrollBarVisibility="Auto">
+  <local:CustomZoomBorder BoundsMode="Custom"
+                          Stretch="None">
+    <!-- content -->
+  </local:CustomZoomBorder>
+</ScrollViewer>
+```
+
+Panning remains bounded by the returned rectangle. Truly infinite panning cannot be represented by finite scrollbars; choose bounds large enough for the application’s workspace.
 
 ## When To Override
 

--- a/site/articles/guides/bounds-wheel-and-resize.md
+++ b/site/articles/guides/bounds-wheel-and-resize.md
@@ -22,7 +22,7 @@ Additional supporting properties:
 - `MinimumVisibleContentPercentage`
 - `EnableConstrains`
 
-Use `Custom` only if you plan to override `GetContentBounds()` or `ValidateTransform(...)`.
+Use `Custom` when a subclass overrides `GetContentBounds()` or `ValidateTransform(...)`. The returned rectangle is expressed in child content coordinates and drives both pan constraints and logical scrollbar extent. See [Custom Bounds, Resize, and Rotation](../advanced/custom-bounds-resize-and-rotation.md) for a large-workspace example.
 
 ## Wheel Behavior
 

--- a/src/PanAndZoom/Model/ContentBoundsMode.cs
+++ b/src/PanAndZoom/Model/ContentBoundsMode.cs
@@ -28,7 +28,9 @@ public enum ContentBoundsMode
     KeepCentered,
 
     /// <summary>
-    /// Use custom bounds logic via virtual method.
+    /// Restrict the viewport and calculate scrollbar extents from the rectangle returned by
+    /// <see cref="ZoomBorder.GetContentBounds"/>. Subclasses can additionally veto the final
+    /// transform by overriding <see cref="ZoomBorder.ValidateTransform"/>.
     /// </summary>
     Custom
 }

--- a/src/PanAndZoom/ZoomBorder.ILogicalScrollable.cs
+++ b/src/PanAndZoom/ZoomBorder.ILogicalScrollable.cs
@@ -38,12 +38,35 @@ public partial class ZoomBorder : ILogicalScrollable
         // The content itself is in a coordinate system from (0,0) to (Width,Height).
         // Only the content bounds get transformed by the matrix.
         
+        var layoutOffset = source.Position;
+        var contentBounds = new Rect(0, 0, source.Width, source.Height);
+        CalculateScrollable(contentBounds, layoutOffset, borderSize, matrix, out extent, out viewport, out offset);
+    }
+
+    /// <summary>
+    /// Calculate scrollable properties for content-coordinate bounds and a separate layout offset.
+    /// </summary>
+    /// <param name="contentBounds">The effective bounds in content coordinates.</param>
+    /// <param name="layoutOffset">The layout position of the child inside the ZoomBorder.</param>
+    /// <param name="borderSize">The size of the ZoomBorder viewport.</param>
+    /// <param name="matrix">The transform matrix.</param>
+    /// <param name="extent">The extent of the scrollable content.</param>
+    /// <param name="viewport">The size of the viewport.</param>
+    /// <param name="offset">The current scroll offset.</param>
+    public static void CalculateScrollable(
+        Rect contentBounds,
+        Point layoutOffset,
+        Size borderSize,
+        Matrix matrix,
+        out Size extent,
+        out Size viewport,
+        out Vector offset)
+    {
         viewport = borderSize;
 
-        // Use helper to transform content bounds to viewport coordinates (accounts for layout offset)
-        var transformed = TransformContentToViewport(source, matrix);
+        var transformed = TransformContentToViewport(contentBounds, layoutOffset, matrix);
         
-        Log($"[CalculateScrollable] source: {source}, transformed: {transformed}");
+        Log($"[CalculateScrollable] contentBounds: {contentBounds}, layoutOffset: {layoutOffset}, transformed: {transformed}");
 
         var width = transformed.Size.Width;
         var height = transformed.Size.Height;
@@ -322,7 +345,11 @@ public partial class ZoomBorder : ILogicalScrollable
             return;
         }
 
-        CalculateScrollable(_element.Bounds, this.Bounds.Size, _matrix, out var extent, out var viewport, out var offset);
+        var contentBounds = BoundsMode == ContentBoundsMode.Custom
+            ? GetContentBounds()
+            : new Rect(0, 0, _element.Bounds.Width, _element.Bounds.Height);
+
+        CalculateScrollable(contentBounds, LayoutOffset, Bounds.Size, _matrix, out var extent, out var viewport, out var offset);
 
         Log($"[InvalidateScrollable] _element.Bounds: {_element.Bounds}, _matrix: {_matrix}");
         Log($"[InvalidateScrollable] _extent: {_extent}, extent: {extent}, diff: {extent - _extent}");

--- a/src/PanAndZoom/ZoomBorder.cs
+++ b/src/PanAndZoom/ZoomBorder.cs
@@ -85,6 +85,7 @@ public partial class ZoomBorder : Border
     private double _lastPinchScale = 1.0;
     private bool _autoFitPending = true;
     private Animation.TransformOperationsTransition? _animationTransition;
+    private Matrix _lastValidMatrix = Matrix.Identity;
 
     // Zoom indicator
     private DispatcherTimer? _zoomIndicatorTimer;
@@ -132,6 +133,9 @@ public partial class ZoomBorder : Border
         this.GetObservable(StretchProperty).Subscribe(new AnonymousObserver<StretchMode>(_ => _autoFitPending = true));
         this.GetObservable(EnableAnimationsProperty).Subscribe(new AnonymousObserver<bool>(_ => UpdateAnimationTransition()));
         this.GetObservable(AnimationDurationProperty).Subscribe(new AnonymousObserver<TimeSpan>(_ => UpdateAnimationTransition()));
+        this.GetObservable(BoundsModeProperty).Subscribe(new AnonymousObserver<ContentBoundsMode>(_ => Invalidate(skipTransitions: true)));
+        this.GetObservable(BoundsPaddingProperty).Subscribe(new AnonymousObserver<Thickness>(_ => Invalidate(skipTransitions: true)));
+        this.GetObservable(MinimumVisibleContentPercentageProperty).Subscribe(new AnonymousObserver<double>(_ => Invalidate(skipTransitions: true)));
     }
 
     /// <summary>
@@ -1939,6 +1943,14 @@ public partial class ZoomBorder : Border
 
         // Apply content bounds restriction
         ApplyContentBoundsRestriction();
+
+        if (BoundsMode == ContentBoundsMode.Custom && !ValidateTransform(_matrix))
+        {
+            _matrix = _lastValidMatrix;
+            return;
+        }
+
+        _lastValidMatrix = _matrix;
     }
 
     private void ApplyContentBoundsRestriction()
@@ -1973,7 +1985,18 @@ public partial class ZoomBorder : Border
     /// <returns>The content bounds rectangle.</returns>
     protected virtual Rect GetContentBounds()
     {
-        return _element?.Bounds ?? new Rect();
+        return _element == null
+            ? default
+            : new Rect(0, 0, _element.Bounds.Width, _element.Bounds.Height);
+    }
+
+    /// <summary>
+    /// Reapplies custom bounds restrictions and refreshes the logical scroll state.
+    /// Call this from a subclass when the value returned by <see cref="GetContentBounds"/> changes.
+    /// </summary>
+    protected void InvalidateContentBounds()
+    {
+        Invalidate(skipTransitions: true);
     }
 
     /// <summary>
@@ -2104,8 +2127,49 @@ public partial class ZoomBorder : Border
 
     private void ApplyCustomBounds(Rect customBounds)
     {
-        // Subclasses can override GetContentBounds and ValidateTransform
-        // for custom bounds logic
+        if (_element == null || customBounds.Width <= 0 || customBounds.Height <= 0)
+        {
+            return;
+        }
+
+        var transformedBounds = TransformContentToViewport(customBounds, LayoutOffset, _matrix);
+        var viewportWidth = Bounds.Width;
+        var viewportHeight = Bounds.Height;
+        var padding = BoundsPadding;
+
+        var targetX = transformedBounds.X;
+        if (transformedBounds.Width <= viewportWidth)
+        {
+            targetX = (viewportWidth - transformedBounds.Width) / 2.0;
+        }
+        else
+        {
+            targetX = ClampValue(
+                transformedBounds.X,
+                viewportWidth - transformedBounds.Width - padding.Left,
+                padding.Right);
+        }
+
+        var targetY = transformedBounds.Y;
+        if (transformedBounds.Height <= viewportHeight)
+        {
+            targetY = (viewportHeight - transformedBounds.Height) / 2.0;
+        }
+        else
+        {
+            targetY = ClampValue(
+                transformedBounds.Y,
+                viewportHeight - transformedBounds.Height - padding.Top,
+                padding.Bottom);
+        }
+
+        _matrix = new Matrix(
+            _matrix.M11,
+            _matrix.M12,
+            _matrix.M21,
+            _matrix.M22,
+            _matrix.M31 + targetX - transformedBounds.X,
+            _matrix.M32 + targetY - transformedBounds.Y);
     }
 
     /// <summary>
@@ -2125,6 +2189,10 @@ public partial class ZoomBorder : Border
         if (EnableConstrains)
         {
             Constrain();
+        }
+        else
+        {
+            _lastValidMatrix = _matrix;
         }
 
         InvalidateProperties();

--- a/tests/Avalonia.Controls.PanAndZoom.UnitTests/ZoomBorderContentBoundsTests.cs
+++ b/tests/Avalonia.Controls.PanAndZoom.UnitTests/ZoomBorderContentBoundsTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Wiesław Šoltés. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
 using Avalonia.Headless.XUnit;
 using Avalonia.Media;
 using Xunit;
@@ -315,4 +316,141 @@ public class ZoomBorderContentBoundsTests
         // Assert - Custom bounds mode doesn't throw
         Assert.NotNull(zoomBorder);
     }
+
+    [AvaloniaFact]
+    public void BoundsMode_Custom_ConstrainsPanningToReturnedBounds()
+    {
+        var zoomBorder = new CustomBoundsZoomBorder
+        {
+            Width = 400,
+            Height = 300,
+            Stretch = StretchMode.None,
+            BoundsMode = ContentBoundsMode.Custom,
+            EnableConstrains = true,
+            CustomBounds = new Rect(-1000, -1000, 2200, 2150),
+            Child = new Border
+            {
+                Width = 200,
+                Height = 150,
+                Background = Brushes.Red
+            }
+        };
+        var window = new Window { Content = zoomBorder };
+        window.Show();
+        window.UpdateLayout();
+
+        zoomBorder.Pan(5000, 5000, skipTransitions: true);
+
+        Assert.Equal(900, zoomBorder.OffsetX, 5);
+        Assert.Equal(925, zoomBorder.OffsetY, 5);
+
+        zoomBorder.Pan(-5000, -5000, skipTransitions: true);
+
+        Assert.Equal(-900, zoomBorder.OffsetX, 5);
+        Assert.Equal(-925, zoomBorder.OffsetY, 5);
+    }
+
+    [AvaloniaFact]
+    public void BoundsMode_Custom_UsesReturnedBoundsForScrollbarState()
+    {
+        var zoomBorder = new CustomBoundsZoomBorder
+        {
+            Width = 400,
+            Height = 300,
+            Stretch = StretchMode.None,
+            BoundsMode = ContentBoundsMode.Custom,
+            EnableConstrains = true,
+            CustomBounds = new Rect(-1000, -1000, 2200, 2150),
+            Child = new Border
+            {
+                Width = 200,
+                Height = 150,
+                Background = Brushes.Red
+            }
+        };
+        var window = new Window { Content = zoomBorder };
+        window.Show();
+        window.UpdateLayout();
+
+        var scrollable = (IScrollable)zoomBorder;
+
+        Assert.Equal(new Size(2200, 2150), scrollable.Extent);
+        Assert.Equal(new Size(400, 300), scrollable.Viewport);
+        Assert.Equal(new Vector(900, 925), scrollable.Offset);
+    }
+
+    [AvaloniaFact]
+    public void BoundsMode_Custom_ValidateTransformCanRejectTransform()
+    {
+        var zoomBorder = new CustomBoundsZoomBorder
+        {
+            Width = 400,
+            Height = 300,
+            Stretch = StretchMode.None,
+            BoundsMode = ContentBoundsMode.Custom,
+            EnableConstrains = true,
+            MaximumAcceptedZoom = 2,
+            CustomBounds = new Rect(-1000, -1000, 2200, 2150),
+            Child = new Border
+            {
+                Width = 200,
+                Height = 150,
+                Background = Brushes.Red
+            }
+        };
+        var window = new Window { Content = zoomBorder };
+        window.Show();
+        window.UpdateLayout();
+
+        zoomBorder.ZoomTo(3, 100, 75, skipTransitions: true);
+
+        Assert.Equal(1, zoomBorder.ZoomX, 5);
+        Assert.Equal(1, zoomBorder.ZoomY, 5);
+        Assert.Equal(0, zoomBorder.OffsetX, 5);
+        Assert.Equal(0, zoomBorder.OffsetY, 5);
+    }
+
+    [AvaloniaFact]
+    public void BoundsMode_Custom_CanRefreshDynamicBounds()
+    {
+        var zoomBorder = new CustomBoundsZoomBorder
+        {
+            Width = 400,
+            Height = 300,
+            Stretch = StretchMode.None,
+            BoundsMode = ContentBoundsMode.Custom,
+            EnableConstrains = true,
+            CustomBounds = new Rect(-1000, -1000, 2200, 2150),
+            Child = new Border
+            {
+                Width = 200,
+                Height = 150,
+                Background = Brushes.Red
+            }
+        };
+        var window = new Window { Content = zoomBorder };
+        window.Show();
+        window.UpdateLayout();
+        var scrollable = (IScrollable)zoomBorder;
+        Assert.Equal(new Size(2200, 2150), scrollable.Extent);
+
+        zoomBorder.CustomBounds = new Rect(0, 0, 200, 150);
+        zoomBorder.RefreshCustomBounds();
+
+        Assert.Equal(new Size(400, 300), scrollable.Extent);
+        Assert.Equal(new Vector(0, 0), scrollable.Offset);
+    }
+}
+
+internal sealed class CustomBoundsZoomBorder : ZoomBorder
+{
+    public Rect CustomBounds { get; set; }
+
+    public double MaximumAcceptedZoom { get; set; } = double.PositiveInfinity;
+
+    protected override Rect GetContentBounds() => CustomBounds;
+
+    protected override bool ValidateTransform(Matrix newMatrix) => newMatrix.M11 <= MaximumAcceptedZoom;
+
+    public void RefreshCustomBounds() => InvalidateContentBounds();
 }


### PR DESCRIPTION
## What changed

- Implement `ContentBoundsMode.Custom` using the content-coordinate rectangle returned by `GetContentBounds()`.
- Constrain panning to that rectangle and use it for logical scrollbar extent and offset calculations.
- Make `ValidateTransform` able to reject the final proposed custom transform.
- Add `InvalidateContentBounds()` for subclasses with dynamic bounds.
- Document a large finite workspace pattern for broad panning with functional scrollbars.
- Add regression tests for both pan limits, scrollbar state, transform rejection, and dynamic bounds refresh.

## Why

The custom mode previously called an empty method. `GetContentBounds()` did not affect transforms or scrollbar calculations, and `ValidateTransform()` was never invoked.

## Validation

- `dotnet test PanAndZoom.slnx --no-restore`

Fixes #140
