### PR TITLE
Upgrade Avalonia to 12.1.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <AvaloniaVersion>12.0.0</AvaloniaVersion>
+    <AvaloniaVersion>12.1.1</AvaloniaVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -18,8 +18,8 @@
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
     <PackageVersion Include="Nuke.Common" Version="10.1.0" />
-    <PackageVersion Include="ProDiagnostics" Version="12.0.0" />
+    <PackageVersion Include="ProDiagnostics" Version="12.1.0.4" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <PackageVersion Include="xunit.v3" Version="3.2.1" />
+    <PackageVersion Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>
 </Project>

--- a/site/articles/getting-started/installation.md
+++ b/site/articles/getting-started/installation.md
@@ -46,8 +46,8 @@ For xUnit headless tests, you also need the standard Avalonia headless test pack
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Avalonia.Headless.XUnit" Version="12.0.0" />
-  <PackageReference Include="Avalonia.Skia" Version="12.0.0" />
+  <PackageReference Include="Avalonia.Headless.XUnit" Version="12.1.1" />
+  <PackageReference Include="Avalonia.Skia" Version="12.1.1" />
 </ItemGroup>
 ```
 

--- a/src/HeadlessTestingFramework/Appium/AvaloniaDriver.cs
+++ b/src/HeadlessTestingFramework/Appium/AvaloniaDriver.cs
@@ -601,7 +601,7 @@ public class AvaloniaDriver : IDisposable
     public void SaveScreenshot(string path)
     {
         var bitmap = Screenshot();
-        bitmap?.Save(path);
+        bitmap?.Save(path, PngBitmapEncoderOptions.Default);
     }
 
     /// <summary>
@@ -615,7 +615,7 @@ public class AvaloniaDriver : IDisposable
             return null;
 
         using var stream = new MemoryStream();
-        bitmap.Save(stream);
+        bitmap.Save(stream, PngBitmapEncoderOptions.Default);
         return Convert.ToBase64String(stream.ToArray());
     }
 

--- a/src/HeadlessTestingFramework/Appium/AvaloniaElement.cs
+++ b/src/HeadlessTestingFramework/Appium/AvaloniaElement.cs
@@ -550,7 +550,7 @@ public class AvaloniaElement
     public void SaveScreenshot(string path)
     {
         var bitmap = Screenshot();
-        bitmap?.Save(path);
+        bitmap?.Save(path, PngBitmapEncoderOptions.Default);
     }
 
     #endregion

--- a/src/HeadlessTestingFramework/GestureRecognizerTestHelper.cs
+++ b/src/HeadlessTestingFramework/GestureRecognizerTestHelper.cs
@@ -134,11 +134,12 @@ public class GestureRecognizerTestHelper
     public void Down(Interactive target, Interactive source, Point position = default, KeyModifiers modifiers = default)
     {
         _pointer.Capture((IInputElement)target);
+        var (root, rootPosition) = ResolveRootPosition(target, position);
         source.RaiseEvent(new PointerPressedEventArgs(
             source, 
             _pointer, 
-            (Visual)source, 
-            position, 
+            root,
+            rootPosition,
             Timestamp(),
             new PointerPointProperties(RawInputModifiers.LeftMouseButton, PointerUpdateKind.LeftButtonPressed),
             modifiers));
@@ -189,7 +190,7 @@ public class GestureRecognizerTestHelper
                 InputElement.PointerMovedEvent, 
                 recognizerTarget, 
                 _pointer, 
-                root, 
+                root,
                 rootPosition,
                 Timestamp(), 
                 new PointerPointProperties(RawInputModifiers.LeftMouseButton, PointerUpdateKind.Other), 
@@ -199,12 +200,13 @@ public class GestureRecognizerTestHelper
         }
         else
         {
+            var (root, rootPosition) = ResolveRootPosition(target, position);
             var e = new PointerEventArgs(
                 InputElement.PointerMovedEvent, 
                 source, 
                 _pointer, 
-                (Visual)target, 
-                position,
+                root,
+                rootPosition,
                 Timestamp(), 
                 new PointerPointProperties(RawInputModifiers.LeftMouseButton, PointerUpdateKind.Other), 
                 modifiers);
@@ -233,11 +235,12 @@ public class GestureRecognizerTestHelper
     /// <param name="modifiers">Key modifiers.</param>
     public void Up(Interactive target, Interactive source, Point position = default, KeyModifiers modifiers = default)
     {
+        var (root, rootPosition) = ResolveRootPosition(target, position);
         var e = new PointerReleasedEventArgs(
             source, 
             _pointer, 
-            (Visual)target, 
-            position, 
+            root,
+            rootPosition,
             Timestamp(),
             new PointerPointProperties(RawInputModifiers.None, PointerUpdateKind.LeftButtonReleased), 
             modifiers, 
@@ -255,6 +258,14 @@ public class GestureRecognizerTestHelper
         }
 
         Cancel();
+    }
+
+    private static (Visual Root, Point Position) ResolveRootPosition(Interactive target, Point position)
+    {
+        var targetVisual = (Visual)target;
+        var root = targetVisual.GetPresentationSource()?.RootVisual as Visual ?? targetVisual;
+        var rootPosition = targetVisual.TransformToVisual(root)?.Transform(position) ?? position;
+        return (root, rootPosition);
     }
 
     /// <summary>

--- a/src/HeadlessTestingFramework/Recording/FrameEncoder.cs
+++ b/src/HeadlessTestingFramework/Recording/FrameEncoder.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Avalonia.Media.Imaging;
 using Avalonia.Platform;
 
 namespace Avalonia.HeadlessTestingFramework.Recording;
@@ -152,7 +153,7 @@ public class PngSequenceEncoder : IFrameEncoder
             }
         }
 
-        bitmap.Save(filePath);
+        bitmap.Save(filePath, PngBitmapEncoderOptions.Default);
     }
 
     private static Avalonia.Platform.PixelFormat ConvertPixelFormat(PixelFormat format)
@@ -267,7 +268,7 @@ public class JpegSequenceEncoder : IFrameEncoder
 
         // Save with quality parameter (requires stream-based save)
         using var stream = File.Create(filePath);
-        bitmap.Save(stream, quality);
+        bitmap.Save(stream, new JpegBitmapEncoderOptions { Quality = quality });
     }
 
     private static Avalonia.Platform.PixelFormat ConvertJpegPixelFormat(PixelFormat format)

--- a/src/HeadlessTestingFramework/TouchInputSimulator.cs
+++ b/src/HeadlessTestingFramework/TouchInputSimulator.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using Avalonia.Input;
 using Avalonia.Input.Raw;
 using Avalonia.Interactivity;
+using Avalonia.VisualTree;
 
 namespace Avalonia.HeadlessTestingFramework;
 
@@ -495,12 +496,13 @@ public class TouchInputSimulator
     {
         var pointer = CreateTouchPointer(touchId);
         var properties = new PointerPointProperties(RawInputModifiers.LeftMouseButton, PointerUpdateKind.LeftButtonPressed);
+        var (root, rootPosition) = ResolveRootPosition(target, position);
         
         return new PointerPressedEventArgs(
             target,
             pointer,
-            (Visual)target,
-            position,
+            root,
+            rootPosition,
             _timestamp,
             properties,
             KeyModifiers.None)
@@ -513,13 +515,14 @@ public class TouchInputSimulator
     {
         var pointer = CreateTouchPointer(touchId);
         var properties = new PointerPointProperties(RawInputModifiers.LeftMouseButton, PointerUpdateKind.Other);
+        var (root, rootPosition) = ResolveRootPosition(target, position);
         
         return new PointerEventArgs(
             InputElement.PointerMovedEvent,
             target,
             pointer,
-            (Visual)target,
-            position,
+            root,
+            rootPosition,
             _timestamp,
             properties,
             KeyModifiers.None);
@@ -529,12 +532,13 @@ public class TouchInputSimulator
     {
         var pointer = CreateTouchPointer(touchId);
         var properties = new PointerPointProperties(RawInputModifiers.None, PointerUpdateKind.LeftButtonReleased);
+        var (root, rootPosition) = ResolveRootPosition(target, position);
         
         return new PointerReleasedEventArgs(
             target,
             pointer,
-            (Visual)target,
-            position,
+            root,
+            rootPosition,
             _timestamp,
             properties,
             KeyModifiers.None,
@@ -542,6 +546,14 @@ public class TouchInputSimulator
         {
             RoutedEvent = InputElement.PointerReleasedEvent
         };
+    }
+
+    private static (Visual Root, Point Position) ResolveRootPosition(Interactive target, Point position)
+    {
+        var targetVisual = (Visual)target;
+        var root = targetVisual.GetPresentationSource()?.RootVisual as Visual ?? targetVisual;
+        var rootPosition = targetVisual.TransformToVisual(root)?.Transform(position) ?? position;
+        return (root, rootPosition);
     }
 
     private PointerDeltaEventArgs CreatePointerDeltaEventArgs(Interactive target, Vector delta, Point position, RoutedEvent routedEvent, KeyModifiers modifiers)


### PR DESCRIPTION
## Summary

- upgrade the centrally managed Avalonia package family to 12.1.1
- align ProDiagnostics and xUnit with Avalonia 12.1 requirements
- adapt synthetic pointer coordinates to Avalonia 12.1 presentation-source semantics
- use the new bitmap encoder options APIs and refresh installation examples

## Validation

- `dotnet restore --force-evaluate`
- `dotnet build PanAndZoom.slnx --no-restore`
- `dotnet test PanAndZoom.slnx --no-build --no-restore`
  - PanAndZoom: 1,216 passed, 1 skipped
  - HeadlessTestingFramework: 113 passed