### PR TITLE
Set version to 12.1.1

### DIFF
--- a/build/Base.props
+++ b/build/Base.props
@@ -1,6 +1,6 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <VersionPrefix>12.0.0.1</VersionPrefix>
+    <VersionPrefix>12.1.1</VersionPrefix>
     <Authors>Wiesław Šoltés</Authors>
     <Company>Wiesław Šoltés</Company>
     <Copyright>Copyright © Wiesław Šoltés 2025</Copyright>


### PR DESCRIPTION
## Summary

- set the PanAndZoom package version to 12.1.1 to match the upgraded Avalonia baseline
- prepare the repository for the `v12.1.1` release tag

## Validation

- `dotnet msbuild src/PanAndZoom/PanAndZoom.csproj -getProperty:Version -getProperty:PackageVersion` returns 12.1.1 for both properties